### PR TITLE
Encode and escape admin slug URLs

### DIFF
--- a/app/controllers/AdminAuthController.php
+++ b/app/controllers/AdminAuthController.php
@@ -24,10 +24,10 @@ class AdminAuthController extends Controller
 
     // Se já estiver logado e o contexto for desta empresa, redireciona
     $u = Auth::user();
-    if ($u && self::sessionCompanyIdMatches($company['id'])) {
-      header('Location: ' . base_url("admin/{$slug}/dashboard"));
-      exit;
-    }
+      if ($u && self::sessionCompanyIdMatches($company['id'])) {
+        header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/dashboard'));
+        exit;
+      }
 
     // Recupera flash message (erro de tentativa anterior)
     $error = $_SESSION['flash_error'] ?? null;
@@ -56,9 +56,9 @@ class AdminAuthController extends Controller
     $pass  = (string)($_POST['password'] ?? '');
 
     if ($email === '' || $pass === '') {
-      $_SESSION['flash_error'] = "Informe e-mail e senha.";
-      header('Location: ' . base_url("admin/{$slug}/login"));
-      exit;
+        $_SESSION['flash_error'] = "Informe e-mail e senha.";
+        header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login'));
+        exit;
     }
 
     $user = User::findByEmail($email);
@@ -85,15 +85,15 @@ class AdminAuthController extends Controller
         $_SESSION['active_company_slug'] = $slug;
 
         // PRG: redireciona para evitar reenvio de POST
-        header('Location: ' . base_url("admin/{$slug}/dashboard"));
-        exit;
+          header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/dashboard'));
+          exit;
       }
     }
 
     // Falha: define flash e volta pro form
-    $_SESSION['flash_error'] = "Credenciais inválidas";
-    header('Location: ' . base_url("admin/{$slug}/login"));
-    exit;
+      $_SESSION['flash_error'] = "Credenciais inválidas";
+      header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login'));
+      exit;
   }
 
   /** GET /admin/{slug}/logout */
@@ -109,7 +109,7 @@ class AdminAuthController extends Controller
     // limpa também o contexto de empresa ativa
     unset($_SESSION['active_company_id'], $_SESSION['active_company_slug']);
 
-    header('Location: ' . base_url("admin/{$slug}/login"));
+    header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login'));
     exit;
   }
 

--- a/app/controllers/AdminCategoryController.php
+++ b/app/controllers/AdminCategoryController.php
@@ -9,7 +9,7 @@ class AdminCategoryController extends Controller {
   private function guard($slug) {
     Auth::start();
     $u = Auth::user();
-    if (!$u) { header('Location: ' . base_url("admin/$slug/login")); exit; }
+      if (!$u) { header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login')); exit; }
     $company = Company::findBySlug($slug);
     if (!$company) { echo "Empresa inválida"; exit; }
     if ($u['role'] !== 'root' && (int)$u['company_id'] !== (int)$company['id']) { echo "Acesso negado"; exit; }
@@ -36,7 +36,7 @@ class AdminCategoryController extends Controller {
       'sort_order'=>(int)$_POST['sort_order'],
       'active'=>isset($_POST['active'])?1:0
     ]);
-    header('Location: ' . base_url("admin/{$company['slug']}/categories"));
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/categories'));
   }
 
   public function edit($params){
@@ -52,12 +52,12 @@ class AdminCategoryController extends Controller {
       'sort_order'=>(int)$_POST['sort_order'],
       'active'=>isset($_POST['active'])?1:0
     ]);
-    header('Location: ' . base_url("admin/{$company['slug']}/categories"));
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/categories'));
   }
 
   public function destroy($params){
     [$u,$company] = $this->guard($params['slug']);
     Category::delete((int)$params['id']);
-    header('Location: ' . base_url("admin/{$company['slug']}/categories"));
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/categories'));
   }
 }

--- a/app/controllers/AdminDashboardController.php
+++ b/app/controllers/AdminDashboardController.php
@@ -18,7 +18,7 @@ class AdminDashboardController extends Controller
 
     // precisa estar logado (admin)
     if (!Auth::checkAdmin()) {
-      header('Location: ' . base_url("admin/{$slug}/login"));
+        header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login'));
       exit;
     }
 

--- a/app/controllers/AdminOrdersController.php
+++ b/app/controllers/AdminOrdersController.php
@@ -12,7 +12,7 @@ class AdminOrdersController extends Controller
     private function guard(string $slug): array {
         Auth::start();
         $u = Auth::user();
-        if (!$u) { header('Location: ' . base_url("admin/$slug/login")); exit; }
+          if (!$u) { header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login')); exit; }
 
         $company = Company::findBySlug($slug);
         if (!$company) { echo "Empresa inválida"; exit; }
@@ -64,7 +64,7 @@ class AdminOrdersController extends Controller
         $status  = $_POST['status'] ?? '';
 
         if (Order::updateStatus($db, $orderId, (int)$company['id'], $status)) {
-            header('Location: ' . base_url("admin/{$company['slug']}/orders/show?id={$orderId}"));
+            header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/orders/show?id=' . $orderId));
             exit;
         }
         http_response_code(400);
@@ -151,7 +151,7 @@ class AdminOrdersController extends Controller
             Order::addItem($db, $orderId, $it);
         }
 
-        header('Location: ' . base_url("admin/{$company['slug']}/orders/show?id={$orderId}"));
+        header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/orders/show?id=' . $orderId));
         exit;
     }
 }

--- a/app/controllers/AdminProductController.php
+++ b/app/controllers/AdminProductController.php
@@ -10,7 +10,7 @@ class AdminProductController extends Controller {
   private function guard($slug) {
     Auth::start();
     $u = Auth::user();
-    if (!$u) { header('Location: ' . base_url("admin/$slug/login")); exit; }
+      if (!$u) { header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login')); exit; }
     $company = Company::findBySlug($slug);
     if (!$company) { echo "Empresa inválida"; exit; }
     if ($u['role'] !== 'root' && (int)$u['company_id'] !== (int)$company['id']) { echo "Acesso negado"; exit; }
@@ -59,7 +59,7 @@ class AdminProductController extends Controller {
       'sort_order'=>(int)$_POST['sort_order'],
     ];
     Product::create($data);
-    header('Location: ' . base_url("admin/{$company['slug']}/products"));
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/products'));
   }
 
   public function edit($params){
@@ -85,12 +85,12 @@ class AdminProductController extends Controller {
       'sort_order'=>(int)$_POST['sort_order'],
     ];
     Product::update((int)$params['id'], $data);
-    header('Location: ' . base_url("admin/{$company['slug']}/products"));
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/products'));
   }
 
   public function destroy($params){
     [$u,$company] = $this->guard($params['slug']);
     Product::delete((int)$params['id']);
-    header('Location: ' . base_url("admin/{$company['slug']}/products"));
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/products'));
   }
 }

--- a/app/controllers/AdminSettingsController.php
+++ b/app/controllers/AdminSettingsController.php
@@ -9,7 +9,7 @@ class AdminSettingsController extends Controller {
   private function guard($slug) {
     Auth::start();
     $u = Auth::user();
-    if (!$u) { header('Location: ' . base_url("admin/$slug/login")); exit; }
+      if (!$u) { header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login')); exit; }
     $company = Company::findBySlug($slug);
     if (!$company) { echo "Empresa inválida"; exit; }
     if ($u['role'] !== 'root' && (int)$u['company_id'] !== (int)$company['id']) { echo "Acesso negado"; exit; }
@@ -112,6 +112,6 @@ class AdminSettingsController extends Controller {
          ->execute([$isOpen, $o1, $c1, $o2, $c2, $company['id'], $d]);
     }
 
-    header('Location: ' . base_url("admin/{$company['slug']}/settings"));
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/settings'));
   }
 }

--- a/app/views/admin/categories/form.php
+++ b/app/views/admin/categories/form.php
@@ -1,10 +1,11 @@
 <?php
 $title = "Categoria - " . ($company['name'] ?? '');
 $editing = !empty($cat['id']);
-$action = $editing ? "admin/{$company['slug']}/categories/{$cat['id']}" : "admin/{$company['slug']}/categories";
+$slug = rawurlencode($company['slug']);
+$action = $editing ? 'admin/' . $slug . '/categories/' . (int)$cat['id'] : 'admin/' . $slug . '/categories';
 ob_start(); ?>
 <h1 class="text-2xl font-bold mb-4"><?= $editing ? 'Editar' : 'Nova' ?> Categoria</h1>
-<form method="post" action="<?= base_url($action) ?>" class="grid gap-3 max-w-lg bg-white p-4 rounded-2xl border">
+  <form method="post" action="<?= e(base_url($action)) ?>" class="grid gap-3 max-w-lg bg-white p-4 rounded-2xl border">
   <label class="grid gap-1">
     <span class="text-sm">Nome</span>
     <input name="name" value="<?= e($cat['name'] ?? '') ?>" class="border rounded-xl p-2">
@@ -19,7 +20,7 @@ ob_start(); ?>
   </label>
   <div class="flex gap-2">
     <button class="px-4 py-2 rounded-xl border">Salvar</button>
-    <a href="<?= base_url("admin/{$company['slug']}/categories") ?>" class="px-4 py-2 rounded-xl border">Cancelar</a>
+      <a href="<?= e(base_url('admin/' . $slug . '/categories')) ?>" class="px-4 py-2 rounded-xl border">Cancelar</a>
   </div>
 </form>
 <?php

--- a/app/views/admin/categories/index.php
+++ b/app/views/admin/categories/index.php
@@ -1,10 +1,11 @@
 <?php
 $title = "Categorias - " . ($company['name'] ?? '');
+$slug = rawurlencode($company['slug']);
 ob_start(); ?>
 <header class="flex items-center gap-3 mb-4">
   <h1 class="text-2xl font-bold">Categorias</h1>
-  <a href="<?= base_url("admin/{$company['slug']}/categories/create") ?>" class="ml-auto px-3 py-2 rounded-xl border">+ Nova</a>
-  <a href="<?= base_url("admin/{$company['slug']}/dashboard") ?>" class="px-3 py-2 rounded-xl border">Dashboard</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/categories/create')) ?>" class="ml-auto px-3 py-2 rounded-xl border">+ Nova</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/dashboard')) ?>" class="px-3 py-2 rounded-xl border">Dashboard</a>
 </header>
 
 <table class="w-full bg-white border rounded-2xl overflow-hidden">
@@ -23,8 +24,8 @@ ob_start(); ?>
       <td class="p-3"><?= (int)$c['sort_order'] ?></td>
       <td class="p-3"><?= $c['active'] ? 'Sim' : 'Não' ?></td>
       <td class="p-3 text-right">
-        <a class="px-3 py-1 border rounded-xl" href="<?= base_url("admin/{$company['slug']}/categories/{$c['id']}/edit") ?>">Editar</a>
-        <form method="post" action="<?= base_url("admin/{$company['slug']}/categories/{$c['id']}/del") ?>" class="inline" onsubmit="return confirm('Excluir categoria?');">
+          <a class="px-3 py-1 border rounded-xl" href="<?= e(base_url('admin/' . $slug . '/categories/' . (int)$c['id'] . '/edit')) ?>">Editar</a>
+          <form method="post" action="<?= e(base_url('admin/' . $slug . '/categories/' . (int)$c['id'] . '/del')) ?>" class="inline" onsubmit="return confirm('Excluir categoria?');">
           <button class="px-3 py-1 border rounded-xl">Excluir</button>
         </form>
       </td>

--- a/app/views/admin/dashboard/index.php
+++ b/app/views/admin/dashboard/index.php
@@ -1,5 +1,7 @@
 <?php
 $title = "Dashboard - " . ($company['name'] ?? 'Empresa');
+$slug = rawurlencode($activeSlug);
+$publicSlug = rawurlencode($company['slug']);
 ob_start(); ?>
 
 <header class="flex items-center gap-3 mb-6">
@@ -12,20 +14,20 @@ ob_start(); ?>
       <?php if (!empty($company['min_order'])): ?> • Mín.: R$ <?= number_format($company['min_order'],2,',','.') ?><?php endif; ?>
     </p>
   </div>
-  <a class="ml-auto px-3 py-2 rounded-xl border" href="<?= base_url("admin/{$activeSlug}/logout") ?>">Sair</a>
+    <a class="ml-auto px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/logout')) ?>">Sair</a>
 </header>
 
 <!-- Abas -->
 <nav class="flex flex-wrap gap-2 mb-5">
-  <a href="<?= base_url("admin/{$activeSlug}/settings") ?>"
+    <a href="<?= e(base_url('admin/' . $slug . '/settings')) ?>"
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">⚙️ Geral</a>
-  <a href="<?= base_url("admin/{$activeSlug}/categories") ?>"
+    <a href="<?= e(base_url('admin/' . $slug . '/categories')) ?>"
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">🗂️ Categorias</a>
-  <a href="<?= base_url("admin/{$activeSlug}/products") ?>"
+    <a href="<?= e(base_url('admin/' . $slug . '/products')) ?>"
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">🧾 Produtos</a>
-  <a href="<?= base_url("admin/{$activeSlug}/orders") ?>"
+    <a href="<?= e(base_url('admin/' . $slug . '/orders')) ?>"
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">📦 Pedidos</a>
-  <a href="<?= base_url($company['slug']) ?>" target="_blank"
+    <a href="<?= e(base_url($publicSlug)) ?>" target="_blank"
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">🔗 Ver cardápio</a>
 </nav>
 
@@ -34,22 +36,22 @@ ob_start(); ?>
   <div class="rounded-2xl bg-white border p-4">
     <div class="text-sm text-gray-500 mb-1">Categorias</div>
     <div class="text-3xl font-bold mb-3"><?= count($categories) ?></div>
-    <a class="px-3 py-2 rounded-xl border inline-block" href="<?= base_url("admin/{$activeSlug}/categories") ?>">Gerenciar</a>
+      <a class="px-3 py-2 rounded-xl border inline-block" href="<?= e(base_url('admin/' . $slug . '/categories')) ?>">Gerenciar</a>
   </div>
 
   <div class="rounded-2xl bg-white border p-4">
     <div class="text-sm text-gray-500 mb-1">Produtos</div>
     <div class="text-3xl font-bold mb-3"><?= count($products) ?></div>
     <div class="flex gap-2">
-      <a class="px-3 py-2 rounded-xl border" href="<?= base_url("admin/{$activeSlug}/products") ?>">Gerenciar</a>
-      <a class="px-3 py-2 rounded-xl border" href="<?= base_url("admin/{$activeSlug}/products/create") ?>">+ Novo</a>
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products')) ?>">Gerenciar</a>
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products/create')) ?>">+ Novo</a>
     </div>
   </div>
 
   <div class="rounded-2xl bg-white border p-4">
     <div class="text-sm text-gray-500 mb-1">Pedidos</div>
     <div class="text-3xl font-bold mb-3">📦</div>
-    <a class="px-3 py-2 rounded-xl border inline-block" href="<?= base_url("admin/{$activeSlug}/orders") ?>">Ver pedidos</a>
+      <a class="px-3 py-2 rounded-xl border inline-block" href="<?= e(base_url('admin/' . $slug . '/orders')) ?>">Ver pedidos</a>
   </div>
 </div>
 
@@ -66,7 +68,7 @@ ob_start(); ?>
       <?php endif; ?>
     </ul>
     <div class="mt-3">
-      <a class="px-3 py-2 rounded-xl border inline-block" href="<?= base_url("admin/{$activeSlug}/categories/create") ?>">+ Nova categoria</a>
+        <a class="px-3 py-2 rounded-xl border inline-block" href="<?= e(base_url('admin/' . $slug . '/categories/create')) ?>">+ Nova categoria</a>
     </div>
   </div>
 
@@ -93,7 +95,7 @@ ob_start(); ?>
               <?php endif; ?>
             </div>
           </div>
-          <a class="px-2 py-1 rounded-lg border text-sm" href="<?= base_url("admin/{$activeSlug}/products/{$p['id']}/edit") ?>">Editar</a>
+            <a class="px-2 py-1 rounded-lg border text-sm" href="<?= e(base_url('admin/' . $slug . '/products/' . (int)$p['id'] . '/edit')) ?>">Editar</a>
         </li>
       <?php endforeach; ?>
       <?php if (!count($show)): ?>
@@ -101,8 +103,8 @@ ob_start(); ?>
       <?php endif; ?>
     </ul>
     <div class="mt-3 flex gap-2">
-      <a class="px-3 py-2 rounded-xl border" href="<?= base_url("admin/{$activeSlug}/products/create") ?>">+ Novo produto</a>
-      <a class="px-3 py-2 rounded-xl border" href="<?= base_url("admin/{$activeSlug}/products") ?>">Ver todos</a>
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products/create')) ?>">+ Novo produto</a>
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products')) ?>">Ver todos</a>
     </div>
   </div>
 </div>

--- a/app/views/admin/orders/form.php
+++ b/app/views/admin/orders/form.php
@@ -1,8 +1,12 @@
-<?php $this->extend('admin/layout.php'); $this->start('content'); ?>
+<?php
+$this->extend('admin/layout.php');
+$this->start('content');
+$slug = $activeSlug ?? ($company['slug'] ?? null);
+?>
 <div class="max-w-3xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Novo pedido</h1>
 
-  <form method="post" action="<?= base_url('admin/orders') ?>" id="order-form" class="space-y-6">
+  <form method="post" action="<?= e(base_url('admin/' . rawurlencode($slug) . '/orders')) ?>" id="order-form" class="space-y-6">
     <!-- Dados do cliente -->
     <div class="rounded-2xl border bg-white p-4">
       <h2 class="font-semibold mb-3">Cliente</h2>
@@ -73,7 +77,7 @@
 
     <div class="flex gap-2">
       <button class="px-4 py-2 rounded-xl border bg-white hover:bg-slate-50">Salvar pedido</button>
-      <a href="<?= base_url('admin/orders') ?>" class="px-4 py-2 rounded-xl border">Cancelar</a>
+      <a href="<?= e(base_url('admin/' . rawurlencode($slug) . '/orders')) ?>" class="px-4 py-2 rounded-xl border">Cancelar</a>
     </div>
   </form>
 </div>

--- a/app/views/admin/orders/index.php
+++ b/app/views/admin/orders/index.php
@@ -4,20 +4,20 @@ ob_start();
 
 /** Resolve URL de voltar (dashboard) */
 $slug = $activeSlug ?? ($company['slug'] ?? null);
-$backUrl = $slug ? base_url("admin/{$slug}/dashboard") : base_url('admin');
+$backUrl = $slug ? base_url('admin/' . rawurlencode($slug) . '/dashboard') : base_url('admin');
 ?>
 <div class="max-w-5xl mx-auto p-4">
   <div class="flex items-center justify-between mb-4">
     <h1 class="text-2xl font-semibold">Pedidos</h1>
     <div class="flex items-center gap-2">
-      <a href="<?= base_url('admin/' . e($slug) . '/orders/create') ?>"
+        <a href="<?= e(base_url('admin/' . rawurlencode($slug) . '/orders/create')) ?>"
          class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">+ Novo pedido</a>
-      <a href="<?= $backUrl ?>"
+        <a href="<?= e($backUrl) ?>"
          class="px-3 py-2 rounded-xl border">← Voltar</a>
     </div>
   </div>
 
-  <form class="mb-4 flex gap-2" method="get" action="<?= base_url('admin/' . e($slug) . '/orders') ?>">
+    <form class="mb-4 flex gap-2" method="get" action="<?= e(base_url('admin/' . rawurlencode($slug) . '/orders')) ?>">
     <select name="status" class="border px-3 py-2 rounded">
       <option value="">Todos</option>
       <?php foreach (['pending'=>'Pendente','paid'=>'Pago','completed'=>'Concluído','canceled'=>'Cancelado'] as $k=>$label): ?>
@@ -48,7 +48,7 @@ $backUrl = $slug ? base_url("admin/{$slug}/dashboard") : base_url('admin');
             <td class="p-2">R$ <?= number_format((float)$o['total'], 2, ',', '.') ?></td>
             <td class="p-2"><?= e($o['created_at']) ?></td>
             <td class="p-2">
-              <a class="underline" href="<?= base_url('admin/' . e($slug) . '/orders/show?id='.(int)$o['id']) ?>">ver</a>
+              <a class="underline" href="<?= e(base_url('admin/' . rawurlencode($slug) . '/orders/show?id=' . (int)$o['id'])) ?>">ver</a>
             </td>
           </tr>
         <?php endforeach; ?>

--- a/app/views/admin/orders/show.php
+++ b/app/views/admin/orders/show.php
@@ -7,10 +7,10 @@ $o = $order;
 <div class="max-w-4xl mx-auto p-4">
   <div class="flex items-center justify-between mb-4">
     <h1 class="text-2xl font-semibold">Pedido #<?= (int)$o['id'] ?></h1>
-    <a class="px-3 py-2 rounded-xl border" href="<?= base_url('admin/' . e($activeSlug) . '/orders') ?>">← Voltar</a>
+      <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . rawurlencode($activeSlug) . '/orders')) ?>">← Voltar</a>
   </div>
 
-  <form method="post" action="<?= base_url('admin/' . e($activeSlug) . '/orders/setStatus') ?>" class="flex items-center gap-2 mb-4">
+    <form method="post" action="<?= e(base_url('admin/' . rawurlencode($activeSlug) . '/orders/setStatus')) ?>" class="flex items-center gap-2 mb-4">
     <input type="hidden" name="id" value="<?= (int)$o['id'] ?>">
     <select name="status" class="border px-3 py-2 rounded">
       <?php foreach (['pending'=>'Pendente','paid'=>'Pago','completed'=>'Concluído','canceled'=>'Cancelado'] as $k=>$label): ?>

--- a/app/views/admin/products/form.php
+++ b/app/views/admin/products/form.php
@@ -1,10 +1,11 @@
 <?php
 $title = "Produto - " . ($company['name'] ?? '');
 $editing = !empty($p['id']);
-$action = $editing ? "admin/{$company['slug']}/products/{$p['id']}" : "admin/{$company['slug']}/products";
+$slug = rawurlencode($company['slug']);
+$action = $editing ? 'admin/' . $slug . '/products/' . (int)$p['id'] : 'admin/' . $slug . '/products';
 ob_start(); ?>
 <h1 class="text-2xl font-bold mb-4"><?= $editing ? 'Editar' : 'Novo' ?> Produto</h1>
-<form method="post" action="<?= base_url($action) ?>" enctype="multipart/form-data" class="grid gap-3 max-w-2xl bg-white p-4 rounded-2xl border">
+  <form method="post" action="<?= e(base_url($action)) ?>" enctype="multipart/form-data" class="grid gap-3 max-w-2xl bg-white p-4 rounded-2xl border">
   <label class="grid gap-1">
     <span class="text-sm">Categoria</span>
     <select name="category_id" class="border rounded-xl p-2">
@@ -61,7 +62,7 @@ ob_start(); ?>
 
   <div class="flex gap-2">
     <button class="px-4 py-2 rounded-xl border">Salvar</button>
-    <a href="<?= base_url("admin/{$company['slug']}/products") ?>" class="px-4 py-2 rounded-xl border">Cancelar</a>
+      <a href="<?= e(base_url('admin/' . $slug . '/products')) ?>" class="px-4 py-2 rounded-xl border">Cancelar</a>
   </div>
 </form>
 <?php

--- a/app/views/admin/products/index.php
+++ b/app/views/admin/products/index.php
@@ -1,11 +1,12 @@
 <?php
 $title = "Produtos - " . ($company['name'] ?? '');
+$slug = rawurlencode($company['slug']);
 ob_start(); ?>
 <header class="flex items-center gap-3 mb-4">
   <h1 class="text-2xl font-bold">Produtos</h1>
-  <a href="<?= base_url("admin/{$company['slug']}/products/create") ?>" class="ml-auto px-3 py-2 rounded-xl border">+ Novo</a>
-  <a href="<?= base_url("admin/{$company['slug']}/categories") ?>" class="px-3 py-2 rounded-xl border">Categorias</a>
-  <a href="<?= base_url("admin/{$company['slug']}/dashboard") ?>" class="px-3 py-2 rounded-xl border">Dashboard</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/products/create')) ?>" class="ml-auto px-3 py-2 rounded-xl border">+ Novo</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/categories')) ?>" class="px-3 py-2 rounded-xl border">Categorias</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/dashboard')) ?>" class="px-3 py-2 rounded-xl border">Dashboard</a>
 </header>
 
 <form method="get" class="mb-3">
@@ -40,8 +41,8 @@ ob_start(); ?>
       <td class="p-3"><?= $p['promo_price'] ? 'R$ '.number_format($p['promo_price'],2,',','.') : '-' ?></td>
       <td class="p-3"><?= $p['active'] ? 'Sim' : 'Não' ?></td>
       <td class="p-3 text-right">
-        <a class="px-3 py-1 border rounded-xl" href="<?= base_url("admin/{$company['slug']}/products/{$p['id']}/edit") ?>">Editar</a>
-        <form method="post" action="<?= base_url("admin/{$company['slug']}/products/{$p['id']}/del") ?>" class="inline" onsubmit="return confirm('Excluir produto?');">
+          <a class="px-3 py-1 border rounded-xl" href="<?= e(base_url('admin/' . $slug . '/products/' . (int)$p['id'] . '/edit')) ?>">Editar</a>
+          <form method="post" action="<?= e(base_url('admin/' . $slug . '/products/' . (int)$p['id'] . '/del')) ?>" class="inline" onsubmit="return confirm('Excluir produto?');">
           <button class="px-3 py-1 border rounded-xl">Excluir</button>
         </form>
       </td>

--- a/app/views/admin/settings/index.php
+++ b/app/views/admin/settings/index.php
@@ -1,11 +1,12 @@
 <?php
 $title = "Configurações - " . ($company['name'] ?? '');
 $days = [1=>'Segunda',2=>'Terça',3=>'Quarta',4=>'Quinta',5=>'Sexta',6=>'Sábado',7=>'Domingo'];
+$slug = rawurlencode($company['slug']);
 ob_start(); ?>
 <h1 class="text-2xl font-bold mb-4">Configurações gerais</h1>
 
 <form id="settingsForm" method="post" enctype="multipart/form-data"
-      action="<?= base_url("admin/{$company['slug']}/settings") ?>"
+       action="<?= e(base_url('admin/' . $slug . '/settings')) ?>"
       class="grid gap-4 max-w-4xl bg-white p-4 rounded-2xl border">
 
   <div class="grid md:grid-cols-2 gap-3">
@@ -111,13 +112,13 @@ ob_start(); ?>
 
   <div class="flex gap-2 mt-3">
     <button class="px-4 py-2 rounded-xl border">Salvar</button>
-    <a href="<?= base_url("admin/{$company['slug']}/dashboard") ?>" class="px-4 py-2 rounded-xl border">Voltar</a>
+      <a href="<?= e(base_url('admin/' . $slug . '/dashboard')) ?>" class="px-4 py-2 rounded-xl border">Voltar</a>
   </div>
 </form>
 
 <div class="mt-6 flex gap-2">
-  <a class="px-3 py-2 rounded-xl border" href="<?= base_url("admin/{$company['slug']}/categories") ?>">Categorias</a>
-  <a class="px-3 py-2 rounded-xl border" href="<?= base_url("admin/{$company['slug']}/products") ?>">Produtos</a>
+  <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/categories')) ?>">Categorias</a>
+  <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products')) ?>">Produtos</a>
 </div>
 
 <script>

--- a/app/views/public/home.php
+++ b/app/views/public/home.php
@@ -146,7 +146,7 @@ $bannerUrl = !empty($company['banner']) ? base_url($company['banner']) : null;
 </div>
 
 <!-- Busca -->
-<form method="get" action="<?= base_url($company['slug'] . '/buscar') ?>" class="mb-4">
+  <form method="get" action="<?= e(base_url(rawurlencode($company['slug']) . '/buscar')) ?>" class="mb-4">
   <input type="text" name="q" value="<?= e($q) ?>" placeholder="Digite para buscar um item"
          class="w-full border rounded-xl px-3 py-2" />
 </form>


### PR DESCRIPTION
## Summary
- URL-encode company slugs when building admin routes
- Escape generated links to prevent HTML injection
- Apply consistent slug handling across controllers and views

## Testing
- `git status --short`
- `git status --short | awk '{print $2}' | xargs -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68ba645f5270832e97a0f3f9ab6d0e86