### PR TITLE
Fix admin order form layout causing error

### DIFF
--- a/app/views/admin/orders/form.php
+++ b/app/views/admin/orders/form.php
@@ -1,6 +1,6 @@
 <?php
-$this->extend('admin/layout.php');
-$this->start('content');
+$title = "Novo pedido";
+ob_start();
 $slug = $activeSlug ?? ($company['slug'] ?? null);
 ?>
 <div class="max-w-3xl mx-auto p-4">
@@ -136,5 +136,8 @@ $slug = $activeSlug ?? ($company['slug'] ?? null);
   addRow();
 })();
 </script>
-<?php $this->end('content'); ?>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layout.php';
+?>
 


### PR DESCRIPTION
## Summary
- Fix order form view so it uses layout include instead of undefined extend/start methods

## Testing
- `php -l app/views/admin/orders/form.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba6ee3811c832e99d197e770a81109