### PR TITLE
Remove redundant autoload config

### DIFF
--- a/app/config/autoload.php
+++ b/app/config/autoload.php
@@ -1,1 +1,0 @@
-public $helpers = ['url','phone'];


### PR DESCRIPTION
## Summary
- remove CodeIgniter's inherited `autoload.php` config

## Testing
- `php -l app/config/app.php`
- `php -l app/config/db.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc72c2cb48832ea863df4cb571330d