### PR TITLE
Add routed customize view for products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # multi-menu
+
+This repository now includes demo product pages.
+
+## Running locally
+
+Use PHP's built-in server to test:
+
+```bash
+php -S localhost:8000 -t public
+```
+
+After seeding data, open `http://localhost:8000/{slug}/product/{id}` in your browser (replace the placeholders with a valid company slug and product ID). The “Personalizar ingredientes” button links to `/{slug}/product/{id}/customize`, and both forms post to simple endpoints that print the submitted data.

--- a/app/controllers/PublicProductController.php
+++ b/app/controllers/PublicProductController.php
@@ -29,4 +29,26 @@ class PublicProductController extends Controller
         $ingredients = Ingredient::listByProduct($id);
         return $this->view('public/product', compact('company', 'product', 'ingredients'));
     }
+
+    public function customize($params)
+    {
+        $slug = $params['slug'] ?? null;
+        $id   = isset($params['id']) ? (int)$params['id'] : 0;
+
+        $company = Company::findBySlug($slug);
+        if (!$company || !$company['active']) {
+            http_response_code(404);
+            echo "Empresa não encontrada";
+            return;
+        }
+
+        $product = Product::find($id);
+        if (!$product || (int)$product['company_id'] !== (int)$company['id'] || (int)($product['active'] ?? 0) !== 1) {
+            http_response_code(404);
+            echo "Produto não encontrado";
+            return;
+        }
+
+        return $this->view('public/customize', compact('company', 'product'));
+    }
 }

--- a/app/views/public/customize.php
+++ b/app/views/public/customize.php
@@ -1,0 +1,231 @@
+<?php
+$product = $product ?? ['id'=>0,'name'=>''];
+
+$addons = [
+  ['id'=>'add_tomate', 'name'=>'Adicionar: Tomate',      'price'=>2.00, 'img'=>'assets/tomate.png',      'min'=>0, 'max'=>5, 'qty'=>0],
+  ['id'=>'add_tasty',  'name'=>'Adicionar: Molho Tasty', 'price'=>3.00, 'img'=>'assets/molho-tasty.png', 'min'=>0, 'max'=>5, 'qty'=>0],
+  ['id'=>'add_maio',   'name'=>'Adicionar: Maionese',    'price'=>3.00, 'img'=>'assets/maionese.png',    'min'=>0, 'max'=>5, 'qty'=>0],
+];
+
+$custom = [
+  'bread' => [
+    'type'   => 'single',
+    'label'  => 'Pão',
+    'value'  => 'pao_brioche',
+    'options'=> [
+      ['id'=>'pao_brioche', 'name'=>'Pão tipo Brioche', 'price'=>0.00, 'img'=>'assets/pao-brioche.png'],
+      ['id'=>'pao_trad',    'name'=>'Pão Tradicional',  'price'=>0.00, 'img'=>'assets/pao-trad.png'],
+    ],
+  ],
+  'items' => [
+    ['id'=>'molho_cbo',     'name'=>'Molho do CBO',         'price'=>3.00, 'img'=>'assets/molho-cbo.png',     'min'=>0, 'max'=>5, 'qty'=>1],
+    ['id'=>'alface',        'name'=>'Alface',               'price'=>2.00, 'img'=>'assets/alface.png',        'min'=>0, 'max'=>5, 'qty'=>1],
+    ['id'=>'bacon',         'name'=>'Bacon',                'price'=>3.00, 'img'=>'assets/bacon.png',         'min'=>0, 'max'=>5, 'qty'=>1],
+    ['id'=>'carne',         'name'=>'Carne 100% Bovina',    'price'=>9.90, 'img'=>'assets/carne.png',         'min'=>0, 'max'=>5, 'qty'=>2],
+    ['id'=>'cheddar',       'name'=>'Fatia Queijo Cheddar', 'price'=>2.00, 'img'=>'assets/cheddar.png',       'min'=>0, 'max'=>5, 'qty'=>2],
+    ['id'=>'cebola_crispy', 'name'=>'Cebola Crispy',        'price'=>2.00, 'img'=>'assets/cebola-crispy.png', 'min'=>0, 'max'=>5, 'qty'=>1],
+    ['id'=>'mequinese',     'name'=>'Mequinese',            'price'=>3.00, 'img'=>'assets/mequinese.png',     'min'=>0, 'max'=>5, 'qty'=>1],
+  ],
+];
+?>
+<!doctype html>
+<html lang="pt-br">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>Personalizar — <?= htmlspecialchars($product['name']) ?></title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#fff;
+    --card:#ffffff;
+    --txt:#111827;
+    --muted:#6b7280;
+    --border:#e5e7eb;
+    --chip:#f3f4f6;
+    --ring:#fbbf24;
+    --cta:#fbbf24;
+    --cta-press:#f59e0b;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;background:var(--bg);color:var(--txt);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial}
+  .app{width:100%;margin:0 auto;min-height:100dvh;display:flex;flex-direction:column}
+  @media (min-width:768px){ .app{max-width:375px} }
+
+  header{position:sticky;top:0;background:#fff;z-index:5}
+  .top{display:flex;align-items:center;gap:10px;padding:12px 12px 6px;border-bottom:1px solid var(--border)}
+  .back{width:36px;height:36px;border:1px solid var(--border);border-radius:999px;background:#fff;display:grid;place-items:center;cursor:pointer}
+  .title{font-weight:600}
+
+  .container{padding:12px 16px 140px}
+
+  .h1{font-size:36px;line-height:1.05;font-weight:800;letter-spacing:-.5px;margin:14px 0 8px}
+  .sub{color:var(--muted);margin-top:-6px}
+
+  .group-title{font-size:28px;line-height:1.15;font-weight:800;margin:28px 0 12px;letter-spacing:-.5px}
+
+  .row{display:flex;align-items:center;gap:12px;padding:14px 12px;border-top:1px solid var(--border)}
+  .row:first-of-type{border-top:0}
+  .thumb{width:52px;height:52px;border-radius:999px;background:var(--chip);display:grid;place-items:center;overflow:hidden}
+  .thumb img{width:100%;height:100%;object-fit:contain}
+  .info{flex:1 1 auto}
+  .name{font-weight:700}
+  .price{color:#374151;font-size:14px;margin-top:2px}
+
+  .stepper{display:flex;align-items:center;gap:10px;border:1px solid var(--border);border-radius:999px;padding:6px 10px;min-width:104px;justify-content:space-between}
+  .st-btn{width:28px;height:28px;border-radius:999px;background:#fff;border:none;display:grid;place-items:center;cursor:pointer}
+  .st-btn svg{width:18px;height:18px}
+  .st-val{min-width:16px;text-align:center;font-weight:600}
+
+  .radio-wrap{margin-left:auto}
+  .radio-btn{width:28px;height:28px;border-radius:999px;border:2px solid var(--ring);display:grid;place-items:center;background:#fff}
+  .radio-btn.sel{background:var(--ring);border-color:var(--ring)}
+  .radio-btn svg{width:16px;height:16px;color:#111;display:none}
+  .radio-btn.sel svg{display:block}
+
+  .footer{position:fixed;left:0;right:0;bottom:0;z-index:6;display:flex;height:64px;border-top:1px solid var(--border);background:#fff}
+  .btn-cancel,.btn-confirm{flex:1 1 50%;font-size:17px;font-weight:600;border:none;cursor:pointer}
+  .btn-cancel{background:#fff;color:#111}
+  .btn-confirm{background:var(--cta);color:#111;transition:background .2s}
+  .btn-confirm:active{background:var(--cta-press)}
+  .homebar{position:absolute;left:50%;transform:translateX(-50%);bottom:8px;width:44%;height:4px;background:#111;border-radius:999px;opacity:.9}
+
+  .hint{color:#6b7280;font-size:12px;margin:6px 2px 12px}
+</style>
+</head>
+<body>
+<form class="app" method="post" action="<?= base_url('save_customization.php') ?>">
+  <header>
+    <div class="top">
+      <button type="button" class="back" onclick="history.back()" aria-label="Voltar">
+        <svg viewBox="0 0 24 24" fill="none"><path d="M15 19l-7-7 7-7" stroke="#111827" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+      <div class="title"><?= htmlspecialchars($product['name']) ?></div>
+    </div>
+  </header>
+
+  <div class="container">
+    <h1 class="h1">Deseja adicionar<br>algum ingrediente?</h1>
+    <div class="sub"><?= htmlspecialchars($product['name']) ?></div>
+
+    <div class="list addons" id="list-addons" aria-label="Adicionais">
+      <?php foreach($addons as $i=>$it): ?>
+        <div class="row" data-id="<?= htmlspecialchars($it['id']) ?>" data-min="<?= (int)$it['min'] ?>" data-max="<?= (int)$it['max'] ?>">
+          <div class="thumb">
+            <img src="<?= htmlspecialchars(base_url($it['img'])) ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'">
+          </div>
+          <div class="info">
+            <div class="name"><?= htmlspecialchars($it['name']) ?></div>
+            <div class="price">R$ <?= number_format($it['price'],2,',','.') ?></div>
+          </div>
+          <div class="stepper">
+            <button class="st-btn" type="button" data-act="dec" aria-label="Diminuir">
+              <svg viewBox="0 0 24 24"><path d="M5 12h14" stroke="#111" stroke-width="2" stroke-linecap="round"/></svg>
+            </button>
+            <div class="st-val" data-role="val"><?= (int)$it['qty'] ?></div>
+            <button class="st-btn" type="button" data-act="inc" aria-label="Aumentar">
+              <svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="#111" stroke-width="2" stroke-linecap="round"/></svg>
+            </button>
+          </div>
+          <input type="hidden" name="addons[<?= htmlspecialchars($it['id']) ?>]" value="<?= (int)$it['qty'] ?>">
+        </div>
+      <?php endforeach; ?>
+    </div>
+
+    <h2 class="group-title">Personalizar <?= htmlspecialchars($product['name']) ?></h2>
+
+    <div class="hint">Escolha 1 opção de pão</div>
+    <?php foreach($custom['bread']['options'] as $opt): $isSel = ($custom['bread']['value'] === $opt['id']); ?>
+      <div class="row radio" data-radio="bread" data-id="<?= htmlspecialchars($opt['id']) ?>">
+        <div class="thumb">
+          <img src="<?= htmlspecialchars(base_url($opt['img'])) ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'">
+        </div>
+        <div class="info">
+          <div class="name"><?= htmlspecialchars($opt['name']) ?></div>
+          <div class="price">R$ <?= number_format($opt['price'],2,',','.') ?></div>
+        </div>
+        <div class="radio-wrap">
+          <div class="radio-btn <?= $isSel?'sel':'' ?>" role="radio" aria-checked="<?= $isSel?'true':'false' ?>" tabindex="0">
+            <svg viewBox="0 0 24 24" fill="none">
+              <path d="M20 6L9 17l-5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </div>
+        </div>
+      </div>
+    <?php endforeach; ?>
+    <input type="hidden" name="custom[bread]" id="f_bread" value="<?= htmlspecialchars($custom['bread']['value']) ?>">
+
+    <div class="list custom-items" id="list-custom-items" aria-label="Personalizar itens">
+      <?php foreach($custom['items'] as $it): ?>
+        <div class="row" data-id="<?= htmlspecialchars($it['id']) ?>" data-min="<?= (int)$it['min'] ?>" data-max="<?= (int)$it['max'] ?>">
+          <div class="thumb">
+            <img src="<?= htmlspecialchars(base_url($it['img'])) ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'">
+          </div>
+          <div class="info">
+            <div class="name"><?= htmlspecialchars($it['name']) ?></div>
+            <div class="price">R$ <?= number_format($it['price'],2,',','.') ?></div>
+          </div>
+          <div class="stepper">
+            <button class="st-btn" type="button" data-act="dec" aria-label="Diminuir">
+              <svg viewBox="0 0 24 24"><path d="M5 12h14" stroke="#111" stroke-width="2" stroke-linecap="round"/></svg>
+            </button>
+            <div class="st-val" data-role="val"><?= (int)$it['qty'] ?></div>
+            <button class="st-btn" type="button" data-act="inc" aria-label="Aumentar">
+              <svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="#111" stroke-width="2" stroke-linecap="round"/></svg>
+            </button>
+          </div>
+          <input type="hidden" name="custom_qty[<?= htmlspecialchars($it['id']) ?>]" value="<?= (int)$it['qty'] ?>">
+        </div>
+      <?php endforeach; ?>
+    </div>
+
+    <input type="hidden" name="product_id" value="<?= (int)$product['id'] ?>">
+  </div>
+
+  <div class="footer">
+    <button type="button" class="btn-cancel" onclick="history.back()">Cancelar</button>
+    <button type="submit" class="btn-confirm">Confirmar</button>
+    <div class="homebar" aria-hidden="true"></div>
+  </div>
+</form>
+
+<script>
+  const clamp = (n,min,max)=> Math.max(min, Math.min(max, n));
+
+  document.querySelectorAll('.row').forEach(row=>{
+    const min = parseInt(row.dataset.min || '0',10);
+    const max = parseInt(row.dataset.max || '99',10);
+    const valEl = row.querySelector('.st-val');
+    const hidden = row.querySelector('input[type="hidden"]');
+    if(!valEl) return;
+    row.querySelectorAll('.st-btn').forEach(btn=>{
+      btn.addEventListener('click', ()=>{
+        const act = btn.dataset.act;
+        const cur = parseInt(valEl.textContent || '0', 10);
+        const next = clamp(cur + (act==='inc'?1:-1), min, max);
+        valEl.textContent = String(next);
+        if(hidden) hidden.value = String(next);
+      });
+    });
+  });
+
+  const breadInput = document.getElementById('f_bread');
+  document.querySelectorAll('.row.radio').forEach(row=>{
+    const id = row.dataset.id;
+    const btn = row.querySelector('.radio-btn');
+    const mark = ()=> {
+      document.querySelectorAll('.row.radio .radio-btn').forEach(b=>{
+        b.classList.remove('sel');
+        b.setAttribute('aria-checked','false');
+      });
+      btn.classList.add('sel');
+      btn.setAttribute('aria-checked','true');
+      breadInput.value = id;
+    };
+    row.addEventListener('click', mark);
+    btn.addEventListener('keydown', (e)=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); mark(); }});
+  });
+</script>
+</body>
+</html>

--- a/app/views/public/partials_card.php
+++ b/app/views/public/partials_card.php
@@ -1,4 +1,4 @@
-<a href="<?= base_url(rawurlencode((string)($company['slug'] ?? '')) . '/produto/' . (int)$p['id']) ?>" class="block">
+<a href="<?= base_url(rawurlencode((string)($company['slug'] ?? '')) . '/product/' . (int)$p['id']) ?>" class="block">
   <div class="rounded-2xl shadow p-4 bg-white border flex gap-3 hover:bg-gray-50">
     <img src="<?= base_url($p['image'] ?: 'assets/logo-placeholder.png') ?>"
          alt="<?= e($p['name']) ?>"

--- a/app/views/public/product.php
+++ b/app/views/public/product.php
@@ -1,5 +1,5 @@
 <?php
-// ===== produto.php (bolinhas pretas + hero full-bleed) =====
+// ===== product.php (bolinhas pretas + hero full-bleed) =====
 // Variáveis vindas do controller
 $product     = $product     ?? [];
 $company     = $company     ?? [];
@@ -81,6 +81,17 @@ $initial = strtoupper(mb_substr($company['name'] ?? '', 0, 1));
     margin-top:7px;flex:0 0 7px;
   }
 
+  .customize-wrap{background:var(--card)}
+  .customize{padding:24px 16px}
+  .btn-outline{
+    width:100%;background:#fff;color:#111;border:1px solid #d8d8d8;
+    border-radius:12px;padding:18px;font-size:18px;font-weight:500;
+    display:flex;align-items:center;justify-content:space-between;text-decoration:none;
+  }
+  .btn-outline:active{background:#f9f9f9}
+  .btn-outline .chev{display:grid;place-items:center}
+  .btn-outline .chev svg{width:22px;height:22px}
+
   .footer{position:sticky;bottom:0;margin-top:auto;background:var(--card);padding:12px 16px 18px;border-top:1px solid var(--border);box-shadow:0 -10px 40px rgba(0,0,0,.06)}
   .cta{width:100%;border:none;border-radius:16px;padding:14px 16px;background:var(--cta);color:#1f2937;font-weight:800;font-size:16px;cursor:pointer}
   .cta:active{background:var(--cta-press)}
@@ -129,7 +140,7 @@ $initial = strtoupper(mb_substr($company['name'] ?? '', 0, 1));
       <p class="body"><?= e($product['description'] ?? '') ?></p>
     </section>
 
-    <section class="section">
+  <section class="section">
       <h3>Ingredientes</h3>
       <ul class="checklist">
         <?php foreach($ingredients as $ing): ?>
@@ -142,7 +153,18 @@ $initial = strtoupper(mb_substr($company['name'] ?? '', 0, 1));
     </section>
   </main>
 
-  <form class="footer" method="post" action="add_to_cart.php" onsubmit="return attach(event)">
+  <div class="customize-wrap">
+    <div class="customize">
+      <a class="btn-outline" href="<?= base_url(rawurlencode((string)($company['slug'] ?? '')) . '/product/' . (int)($product['id'] ?? 0) . '/customize') ?>">
+        <span>Personalizar ingredientes</span>
+        <span class="chev" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none"><path d="M9 5l7 7-7 7" stroke="#111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </span>
+      </a>
+    </div>
+  </div>
+
+  <form class="footer" method="post" action="<?= base_url('add_to_cart.php') ?>" onsubmit="return attach(event)">
     <input type="hidden" name="product_id" value="<?= (int)($product['id'] ?? 0) ?>">
     <input type="hidden" name="qty" id="qtyField" value="1">
     <button class="cta" type="submit">Adicionar à Sacola</button>

--- a/public/add_to_cart.php
+++ b/public/add_to_cart.php
@@ -1,0 +1,6 @@
+<?php
+// Demo endpoint to inspect POST data from product.php form
+header('Content-Type: text/plain; charset=utf-8');
+
+echo "Dados recebidos:\n";
+print_r($_POST);

--- a/public/index.php
+++ b/public/index.php
@@ -9,7 +9,8 @@ $router = new Router();
 /* Rotas públicas (cardápio) */
 $router->get('/{slug}', 'PublicHomeController@index');
 $router->get('/{slug}/buscar', 'PublicHomeController@buscar');
-$router->get('/{slug}/produto/{id}', 'PublicProductController@show');
+$router->get('/{slug}/product/{id}', 'PublicProductController@show');
+$router->get('/{slug}/product/{id}/customize', 'PublicProductController@customize');
 
 /* Rotas cliente (login por nome + WhatsApp) */
 $router->post('/{slug}/customer-login',  'CustomerAuthController@login');

--- a/public/save_customization.php
+++ b/public/save_customization.php
@@ -1,0 +1,6 @@
+<?php
+// Demo endpoint to inspect POST data from customize.php form
+header('Content-Type: text/plain; charset=utf-8');
+
+echo "Personalização recebida:\n";
+print_r($_POST);


### PR DESCRIPTION
## Summary
- move demo product and customize pages into `app/views/public`
- expose `/product/{id}/customize` through controller and router
- link product page to customization form and update docs

## Testing
- `php -l app/views/public/customize.php`
- `php -l app/views/public/product.php`
- `php -l app/controllers/PublicProductController.php`
- `php -l public/index.php`
- `php -l public/add_to_cart.php`
- `php -l public/save_customization.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2fbeecd70832ea6df6aa7802fc830