### PR TITLE
feat: store cart items in session

### DIFF
--- a/public/add_to_cart.php
+++ b/public/add_to_cart.php
@@ -1,6 +1,37 @@
 <?php
-// Demo endpoint to inspect POST data from product.php form
-header('Content-Type: text/plain; charset=utf-8');
+session_start();
 
-echo "Dados recebidos:\n";
-print_r($_POST);
+if (!isset($_SESSION['cart'])) {
+    $_SESSION['cart'] = [];
+}
+
+$productId = isset($_POST['product_id']) ? (int)$_POST['product_id'] : 0;
+$qty = isset($_POST['qty']) ? max(1, (int)$_POST['qty']) : 1;
+$combo = [];
+if (isset($_POST['combo']) && is_array($_POST['combo'])) {
+    foreach ($_POST['combo'] as $gi => $id) {
+        $combo[(int)$gi] = (int)$id;
+    }
+}
+
+if ($productId > 0) {
+    $_SESSION['cart'][] = [
+        'product_id' => $productId,
+        'qty' => $qty,
+        'combo' => $combo,
+    ];
+    $message = 'Item adicionado à sacola!';
+} else {
+    $message = 'Produto inválido.';
+}
+
+header('Content-Type: text/html; charset=utf-8');
+?>
+<!doctype html>
+<html lang="pt-br">
+<head><meta charset="utf-8"><title>Sacola</title></head>
+<body>
+<p><?= htmlspecialchars($message, ENT_QUOTES, 'UTF-8') ?></p>
+<a href="index.php">Voltar</a>
+</body>
+</html>

--- a/public/save_customization.php
+++ b/public/save_customization.php
@@ -1,6 +1,55 @@
 <?php
-// Demo endpoint to inspect POST data from customize.php form
-header('Content-Type: text/plain; charset=utf-8');
+session_start();
 
-echo "Personalização recebida:\n";
-print_r($_POST);
+if (!isset($_SESSION['customizations'])) {
+    $_SESSION['customizations'] = [];
+}
+
+$productId = isset($_POST['product_id']) ? (int)$_POST['product_id'] : 0;
+
+$addons = [];
+if (isset($_POST['addons']) && is_array($_POST['addons'])) {
+    foreach ($_POST['addons'] as $k => $qty) {
+        $addons[(string)$k] = (int)$qty;
+    }
+}
+
+$customSingle = [];
+if (isset($_POST['custom_single']) && is_array($_POST['custom_single'])) {
+    foreach ($_POST['custom_single'] as $g => $idx) {
+        $customSingle[(int)$g] = (int)$idx;
+    }
+}
+
+$customQty = [];
+if (isset($_POST['custom_qty']) && is_array($_POST['custom_qty'])) {
+    foreach ($_POST['custom_qty'] as $g => $items) {
+        if (is_array($items)) {
+            foreach ($items as $i => $qty) {
+                $customQty[(int)$g][(int)$i] = (int)$qty;
+            }
+        }
+    }
+}
+
+if ($productId > 0) {
+    $_SESSION['customizations'][$productId] = [
+        'addons' => $addons,
+        'single' => $customSingle,
+        'qty'    => $customQty,
+    ];
+    $message = 'Personalização salva!';
+} else {
+    $message = 'Produto inválido.';
+}
+
+header('Content-Type: text/html; charset=utf-8');
+?>
+<!doctype html>
+<html lang="pt-br">
+<head><meta charset="utf-8"><title>Personalização</title></head>
+<body>
+<p><?= htmlspecialchars($message, ENT_QUOTES, 'UTF-8') ?></p>
+<a href="index.php">Voltar</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- save cart items to session with product, quantity, and combo selections
- persist product customizations in session for addons and option groups

## Testing
- `php -l public/add_to_cart.php`
- `php -l public/save_customization.php`


------
https://chatgpt.com/codex/tasks/task_e_68c73551f8c4832ea0ed40793ec1b979