### PR TITLE
Fix product page and ingredient handling

### DIFF
--- a/app/controllers/AdminProductController.php
+++ b/app/controllers/AdminProductController.php
@@ -5,7 +5,6 @@ require_once __DIR__ . '/../core/Auth.php';
 require_once __DIR__ . '/../models/Company.php';
 require_once __DIR__ . '/../models/Category.php';
 require_once __DIR__ . '/../models/Product.php';
-require_once __DIR__ . '/../models/Ingredient.php';
 
 class AdminProductController extends Controller {
   private function guard($slug) {
@@ -116,7 +115,7 @@ class AdminProductController extends Controller {
     ];
     $pid = Product::create($data);
     $ings = array_filter(array_map('trim', $_POST['ingredients'] ?? []));
-    if ($ings) Ingredient::replaceForProduct($pid, $ings);
+    Product::saveIngredients($pid, $ings);
     header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/products'));
   }
 
@@ -124,7 +123,7 @@ class AdminProductController extends Controller {
     [$u,$company] = $this->guard($params['slug']);
     $cats = Category::allByCompany((int)$company['id']);
     $p = Product::find((int)$params['id']);
-    $ingredients = Ingredient::listByProduct((int)$params['id']);
+    $ingredients = Product::getIngredients((int)$params['id']);
     return $this->view('admin/products/form', compact('company','cats','p','ingredients'));
   }
 
@@ -149,7 +148,7 @@ class AdminProductController extends Controller {
     ];
     Product::update((int)$params['id'], $data);
     $ings = array_filter(array_map('trim', $_POST['ingredients'] ?? []));
-    Ingredient::replaceForProduct((int)$params['id'], $ings);
+    Product::saveIngredients((int)$params['id'], $ings);
     header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/products'));
   }
 

--- a/app/controllers/PublicProductController.php
+++ b/app/controllers/PublicProductController.php
@@ -4,7 +4,6 @@ require_once __DIR__ . '/../core/Controller.php';
 require_once __DIR__ . '/../core/Helpers.php';
 require_once __DIR__ . '/../models/Company.php';
 require_once __DIR__ . '/../models/Product.php';
-require_once __DIR__ . '/../models/Ingredient.php';
 
 class PublicProductController extends Controller
 {
@@ -42,7 +41,7 @@ class PublicProductController extends Controller
         }
 
         // Ingredientes (lista simples)
-        $ingredients = Ingredient::listByProduct($id);
+        $ingredients = Product::getIngredients($id);
 
         // Grupos de opções (combo) — somente se tipo != 'simple'
         $groups = [];
@@ -54,45 +53,6 @@ class PublicProductController extends Controller
         // Renderiza a view pública
         // A view espera: $company, $product, $ingredients, $groups
         return $this->view('public/product', compact('company', 'product', 'ingredients', 'groups'));
-    }
-
-    /**
-     * (Opcional) GET /{slug}/produto/{id}/customizar
-     * Deixe este método se você adicionou a rota de customização.
-     * Aqui você pode carregar dados extras (mods/addons) quando tiver os modelos correspondentes.
-     */
-    public function customize($params)
-    {
-        $slug = $params['slug'] ?? null;
-        $id   = isset($params['id']) ? (int)$params['id'] : 0;
-
-        $company = Company::findBySlug($slug);
-        if (!$company || (int)($company['active'] ?? 0) !== 1) {
-            http_response_code(404);
-            echo "Empresa não encontrada";
-            return;
-        }
-
-        $product = Product::find($id);
-        if (
-            !$product ||
-            (int)$product['company_id'] !== (int)$company['id'] ||
-            (int)($product['active'] ?? 0) !== 1
-        ) {
-            http_response_code(404);
-            echo "Produto não encontrado";
-            return;
-        }
-
-        // Se você tiver tabelas/modelos de mods/addons, carregue-os aqui.
-        // Exemplo:
-        // $mods = Mods::listByProduct($id);
-        // $addons = Addon::listByCompany($company['id']);
-        // return $this->view('public/customize', compact('company','product','mods','addons'));
-
-        // Por enquanto, só redireciona de volta ao produto
-        redirect(base_url($slug.'/produto/'.$id));
-        return;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Load ingredient list through Product model to avoid controller errors
- Save and fetch ingredients with Product::saveIngredients/getIngredients
- Remove duplicate customize method causing product view failures

## Testing
- `php -l app/controllers/PublicProductController.php`
- `php -l app/controllers/AdminProductController.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7378894b4832e98bc03fcdcf91d32