### PR TITLE
Return ingredient arrays

### DIFF
--- a/app/controllers/AdminProductController.php
+++ b/app/controllers/AdminProductController.php
@@ -123,7 +123,9 @@ class AdminProductController extends Controller {
     [$u,$company] = $this->guard($params['slug']);
     $cats = Category::allByCompany((int)$company['id']);
     $p = Product::find((int)$params['id']);
-    $ingredients = Product::getIngredients((int)$params['id']);
+    // getIngredients agora retorna [['name'=>...], ...]; extrai apenas os nomes
+    $ingredientsRows = Product::getIngredients((int)$params['id']);
+    $ingredients = array_map(fn($r) => $r['name'], $ingredientsRows);
     return $this->view('admin/products/form', compact('company','cats','p','ingredients'));
   }
 

--- a/app/models/Product.php
+++ b/app/models/Product.php
@@ -159,7 +159,10 @@ class Product
    * INGREDIENTES
    * ======================== */
 
-  /** Lê a lista simples de ingredientes do produto (tabela: product_ingredients) */
+  /**
+   * Lê a lista simples de ingredientes do produto (tabela: product_ingredients)
+   * e retorna cada item como ['name' => <string>].
+   */
   public static function getIngredients(int $productId): array {
     $sql = "SELECT name
               FROM product_ingredients
@@ -167,7 +170,7 @@ class Product
           ORDER BY sort ASC, id ASC";
     $st = db()->prepare($sql);
     $st->execute([$productId]);
-    return array_map(fn($r)=>$r['name'], $st->fetchAll(PDO::FETCH_ASSOC));
+    return $st->fetchAll(PDO::FETCH_ASSOC);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Return ingredient lists as arrays with `name` keys
- Adapt admin edit action to extract ingredient names for the form

## Testing
- `php -l app/models/Product.php`
- `php -l app/controllers/AdminProductController.php`
- `php -l app/controllers/PublicProductController.php`


------
https://chatgpt.com/codex/tasks/task_e_68c73ab0a798832e86861f723d527939