### PR TITLE
Return structured ingredient arrays

### DIFF
--- a/app/controllers/AdminProductController.php
+++ b/app/controllers/AdminProductController.php
@@ -124,8 +124,8 @@ class AdminProductController extends Controller {
     $cats = Category::allByCompany((int)$company['id']);
     $p = Product::find((int)$params['id']);
     // getIngredients agora retorna [['name'=>...], ...]; extrai apenas os nomes
-    $ingredientsRows = Product::getIngredients((int)$params['id']);
-    $ingredients = array_map(fn($r) => $r['name'], $ingredientsRows);
+    $ingredientRows = Product::getIngredients((int)$params['id']);
+    $ingredients    = array_map(fn($r) => $r['name'], $ingredientRows);
     return $this->view('admin/products/form', compact('company','cats','p','ingredients'));
   }
 

--- a/app/controllers/PublicProductController.php
+++ b/app/controllers/PublicProductController.php
@@ -40,7 +40,7 @@ class PublicProductController extends Controller
             return;
         }
 
-        // Ingredientes (lista simples)
+        // Ingredientes (lista simples) no formato [['name'=>...], ...]
         $ingredients = Product::getIngredients($id);
 
         // Grupos de opções (combo) — somente se tipo != 'simple'

--- a/app/models/Product.php
+++ b/app/models/Product.php
@@ -170,7 +170,9 @@ class Product
           ORDER BY sort ASC, id ASC";
     $st = db()->prepare($sql);
     $st->execute([$productId]);
-    return $st->fetchAll(PDO::FETCH_ASSOC);
+    // Retorna cada item no formato ['name' => <string>]
+    $names = $st->fetchAll(PDO::FETCH_COLUMN);
+    return array_map(fn($n) => ['name' => $n], $names);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Ensure `Product::getIngredients` returns ingredients as arrays with `name`
- Update admin product edit to extract ingredient names from structured rows
- Clarify ingredient format in public product controller

## Testing
- `php -l app/models/Product.php`
- `php -l app/controllers/AdminProductController.php`
- `php -l app/controllers/PublicProductController.php`


------
https://chatgpt.com/codex/tasks/task_e_68c76b669c88832eaba63663398c22f0