### PR TITLE
Implement normalized product customization flow

### DIFF
--- a/app/models/ProductCustomization.php
+++ b/app/models/ProductCustomization.php
@@ -1,0 +1,249 @@
+<?php
+// app/models/ProductCustomization.php
+require_once __DIR__ . '/../config/db.php';
+
+class ProductCustomization
+{
+    /**
+     * Normaliza os dados vindos do formulário do admin.
+     * Retorna um array no formato ['enabled'=>bool,'groups'=>[...]].
+     */
+    public static function sanitizePayload(array $payload): array
+    {
+        $enabled = !empty($payload['enabled']);
+        $groups  = [];
+
+        if (!empty($payload['groups']) && is_array($payload['groups'])) {
+            $groups = self::normalizeGroups($payload['groups']);
+        }
+
+        if (!$groups) {
+            $enabled = false;
+        }
+
+        return [
+            'enabled' => $enabled,
+            'groups'  => $groups,
+        ];
+    }
+
+    /**
+     * Persiste os grupos/itens de personalização de um produto.
+     * Espera receber os dados já normalizados via sanitizePayload().
+     */
+    public static function save(int $productId, array $customization): void
+    {
+        $enabled = !empty($customization['enabled']) && !empty($customization['groups']);
+        $groups  = $enabled ? $customization['groups'] : [];
+
+        $pdo = db();
+        $pdo->beginTransaction();
+        try {
+            $pdo->prepare("DELETE pci FROM product_custom_items pci
+                              INNER JOIN product_custom_groups pcg ON pcg.id = pci.group_id
+                             WHERE pcg.product_id = ?")
+                ->execute([$productId]);
+
+            $pdo->prepare("DELETE FROM product_custom_groups WHERE product_id = ?")
+                ->execute([$productId]);
+
+            if ($groups) {
+                $insGroup = $pdo->prepare(
+                    "INSERT INTO product_custom_groups (product_id, name, type, min_qty, max_qty, sort_order)
+                     VALUES (?,?,?,?,?,?)"
+                );
+                $insItem = $pdo->prepare(
+                    "INSERT INTO product_custom_items (group_id, label, delta, is_default, sort_order)
+                     VALUES (?,?,?,?,?)"
+                );
+
+                foreach ($groups as $gIndex => $group) {
+                    $insGroup->execute([
+                        $productId,
+                        $group['name'],
+                        $group['type'],
+                        $group['min'],
+                        $group['max'],
+                        $group['sort_order'] ?? $gIndex,
+                    ]);
+                    $groupId = (int)$pdo->lastInsertId();
+
+                    $items = $group['items'] ?? [];
+                    foreach ($items as $iIndex => $item) {
+                        $insItem->execute([
+                            $groupId,
+                            $item['label'],
+                            isset($item['delta']) ? (float)$item['delta'] : 0.00,
+                            !empty($item['default']) ? 1 : 0,
+                            $item['sort_order'] ?? $iIndex,
+                        ]);
+                    }
+                }
+            }
+
+            $pdo->commit();
+        } catch (Throwable $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Carrega grupos/itens para uso no formulário do admin.
+     */
+    public static function loadForAdmin(int $productId): array
+    {
+        return self::fetchGroups($productId);
+    }
+
+    /**
+     * Carrega grupos/itens para uso no front público (product/customization).
+     */
+    public static function loadForPublic(int $productId): array
+    {
+        $groups = self::fetchGroups($productId);
+        foreach ($groups as &$group) {
+            foreach ($group['items'] as &$item) {
+                $item['name'] = $item['label'];
+                if (!array_key_exists('delta', $item)) {
+                    $item['delta'] = 0.0;
+                }
+                $item['img'] = $item['img'] ?? null;
+            }
+            unset($item);
+        }
+        unset($group);
+        return $groups;
+    }
+
+    /**
+     * Normaliza grupos vindos do formulário do admin.
+     */
+    private static function normalizeGroups(array $groups): array
+    {
+        $normalized = [];
+        $gSort = 0;
+        foreach ($groups as $group) {
+            if (!is_array($group)) continue;
+
+            $name = trim((string)($group['name'] ?? ''));
+            if ($name === '') continue;
+
+            $min = isset($group['min']) ? max(0, (int)$group['min']) : 0;
+            $max = isset($group['max']) ? max(0, (int)$group['max']) : 99;
+            if ($max < $min) {
+                $max = $min;
+            }
+
+            $itemsRaw = $group['items'] ?? [];
+            if (!is_array($itemsRaw)) {
+                $itemsRaw = [];
+            }
+
+            $items = [];
+            $iSort = 0;
+            foreach ($itemsRaw as $item) {
+                if (!is_array($item)) continue;
+                $label = trim((string)($item['label'] ?? ''));
+                if ($label === '') continue;
+
+                $items[] = [
+                    'label'      => $label,
+                    'delta'      => isset($item['delta']) ? (float)$item['delta'] : 0.0,
+                    'default'    => !empty($item['default']),
+                    'sort_order' => $iSort++,
+                ];
+            }
+
+            if (!$items) continue;
+
+            $type = ($min === 1 && $max === 1) ? 'single' : 'extra';
+            if ($type === 'single') {
+                $defaultApplied = false;
+                foreach ($items as &$it) {
+                    if ($defaultApplied) {
+                        $it['default'] = false;
+                        continue;
+                    }
+                    if (!empty($it['default'])) {
+                        $defaultApplied = true;
+                    }
+                }
+                unset($it);
+                if (!$defaultApplied && isset($items[0])) {
+                    $items[0]['default'] = true;
+                }
+            }
+
+            $normalized[] = [
+                'name'       => $name,
+                'type'       => $type,
+                'min'        => $min,
+                'max'        => $max,
+                'sort_order' => $gSort++,
+                'items'      => $items,
+            ];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Consulta grupos/itens no banco.
+     */
+    private static function fetchGroups(int $productId): array
+    {
+        $pdo = db();
+        $sql = "SELECT pcg.id          AS group_id,
+                       pcg.name        AS group_name,
+                       pcg.type        AS group_type,
+                       pcg.min_qty     AS group_min,
+                       pcg.max_qty     AS group_max,
+                       pcg.sort_order  AS group_sort,
+                       pci.id          AS item_id,
+                       pci.label       AS item_label,
+                       pci.delta       AS item_delta,
+                       pci.is_default  AS item_default,
+                       pci.sort_order  AS item_sort
+                  FROM product_custom_groups pcg
+             LEFT JOIN product_custom_items  pci ON pci.group_id = pcg.id
+                 WHERE pcg.product_id = ?
+              ORDER BY pcg.sort_order ASC, pcg.id ASC, pci.sort_order ASC, pci.id ASC";
+
+        $st = $pdo->prepare($sql);
+        $st->execute([$productId]);
+        $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+
+        if (!$rows) {
+            return [];
+        }
+
+        $groups = [];
+        foreach ($rows as $row) {
+            $gid = (int)$row['group_id'];
+            if (!isset($groups[$gid])) {
+                $groups[$gid] = [
+                    'id'         => $gid,
+                    'name'       => $row['group_name'],
+                    'type'       => $row['group_type'] ?: 'extra',
+                    'min'        => (int)$row['group_min'],
+                    'max'        => (int)$row['group_max'],
+                    'sort_order' => (int)$row['group_sort'],
+                    'items'      => [],
+                ];
+            }
+
+            if (!empty($row['item_id'])) {
+                $groups[$gid]['items'][] = [
+                    'id'         => (int)$row['item_id'],
+                    'label'      => $row['item_label'],
+                    'delta'      => (float)$row['item_delta'],
+                    'default'    => (bool)$row['item_default'],
+                    'sort_order' => (int)$row['item_sort'],
+                ];
+            }
+        }
+
+        return array_values($groups);
+    }
+}

--- a/app/views/public/customization.php
+++ b/app/views/public/customization.php
@@ -24,9 +24,10 @@ foreach (($mods ?? []) as $gIndex => $g) {
     foreach ($items as $it) {
       $delta = (float)($it['delta'] ?? 0);
       if ($delta > 0) {
+        $itemName = $it['name'] ?? $it['label'] ?? '';
         $addons[] = [
-          'id'   => md5(($g['name'] ?? 'grp').('|').($it['name'] ?? 'item')),
-          'name' => 'Adicionar: ' . (string)($it['name'] ?? ''),
+          'id'   => md5(($g['name'] ?? 'grp').('|').($itemName !== '' ? $itemName : 'item')),
+          'name' => 'Adicionar: ' . (string)$itemName,
           'price'=> $delta,
           'img'  => $it['img'] ?? null,
           'min'  => isset($it['min']) ? (int)$it['min'] : 0,
@@ -118,7 +119,7 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
                data-min="<?= (int)$it['min'] ?>" data-max="<?= (int)$it['max'] ?>">
             <div class="thumb"><img src="<?= e($img) ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'"></div>
             <div class="info">
-              <div class="name"><?= e($it['name']) ?></div>
+              <div class="name"><?= e($it['name'] ?? $it['label'] ?? '') ?></div>
               <div class="price"><?= price_br($it['price']) ?></div>
             </div>
             <div class="stepper">
@@ -163,7 +164,8 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
             <div class="row radio" data-radio="g<?= (int)$gi ?>" data-id="<?= (int)$ii ?>">
               <div class="thumb"><img src="<?= e($img ?: 'https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+') ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'"></div>
               <div class="info">
-                <div class="name"><?= e($it['name'] ?? ('Opção '.($ii+1))) ?></div>
+                <?php $optName = $it['name'] ?? $it['label'] ?? ('Opção '.($ii+1)); ?>
+                <div class="name"><?= e($optName) ?></div>
                 <?php if (!empty($it['delta'])): ?>
                   <div class="price">+ <?= price_br((float)$it['delta']) ?></div>
                 <?php else: ?>
@@ -190,7 +192,8 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
               <div class="row" data-id="<?= (int)$ii ?>" data-min="<?= $min ?>" data-max="<?= $max ?>">
                 <div class="thumb"><img src="<?= e($img ?: 'https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+') ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'"></div>
                 <div class="info">
-                  <div class="name"><?= e($it['name'] ?? ('Item '.($ii+1))) ?></div>
+                  <?php $itemName = $it['name'] ?? $it['label'] ?? ('Item '.($ii+1)); ?>
+                  <div class="name"><?= e($itemName) ?></div>
                   <div class="price"><?= $delta>0 ? '+ '.price_br($delta) : price_br(0) ?></div>
                 </div>
                 <div class="stepper">

--- a/app/views/public/product.php
+++ b/app/views/public/product.php
@@ -10,8 +10,9 @@ if (!function_exists('price_br')) { function price_br($v){ return 'R$ ' . number
 /** Variáveis básicas */
 $company = $company ?? [];
 $product = $product ?? [];
-$simpleMods = $simpleMods ?? null;
 $comboGroups = $comboGroups ?? null;
+$mods = $mods ?? [];
+$hasCustomization = isset($hasCustomization) ? (bool)$hasCustomization : (!empty($mods));
 
 $slug  = (string)($company['slug'] ?? '');
 $pId   = (int)($product['id'] ?? 0);
@@ -148,8 +149,8 @@ $addToCartUrl  = base_url($slug . '/orders/add');                               
 
   </main>
 
-  <!-- Botão PERSONALIZAR: visível se houver mods simples -->
-  <?php if (!empty($simpleMods['items'])): ?>
+  <!-- Botão PERSONALIZAR: visível se houver personalização disponível -->
+  <?php if ($hasCustomization): ?>
   <div class="customize-wrap">
     <div class="customize">
       <?php

--- a/database/migrations/20230901_create_product_customization_tables.sql
+++ b/database/migrations/20230901_create_product_customization_tables.sql
@@ -1,0 +1,21 @@
+-- Tabelas de personalização de produtos
+CREATE TABLE IF NOT EXISTS product_custom_groups (
+  id         INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  product_id INT UNSIGNED NOT NULL,
+  name       VARCHAR(200) NOT NULL,
+  type       ENUM('single','extra','addon','component') NOT NULL DEFAULT 'extra',
+  min_qty    INT NOT NULL DEFAULT 0,
+  max_qty    INT NOT NULL DEFAULT 99,
+  sort_order INT NOT NULL DEFAULT 0,
+  CONSTRAINT fk_pcg_product FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS product_custom_items (
+  id         INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  group_id   INT UNSIGNED NOT NULL,
+  label      VARCHAR(200) NOT NULL,
+  delta      DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+  is_default TINYINT(1) NOT NULL DEFAULT 0,
+  sort_order INT NOT NULL DEFAULT 0,
+  CONSTRAINT fk_pci_group FOREIGN KEY (group_id) REFERENCES product_custom_groups(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- add a ProductCustomization model that normalizes, persists and reads product customization groups/items
- wire product customization handling into the admin product controller and public product/customization routes
- adjust public views and add SQL migration for the normalized customization tables

## Testing
- php -l app/models/ProductCustomization.php
- php -l app/controllers/AdminProductController.php
- php -l app/controllers/PublicProductController.php
- php -l app/views/public/product.php
- php -l app/views/public/customization.php

------
https://chatgpt.com/codex/tasks/task_e_68ccdabf54d0832ebd97b541b8b5c302