### PR TITLE
Align product customization product_id column types with products

### DIFF
--- a/database/menu_schema_with_customization.sql
+++ b/database/menu_schema_with_customization.sql
@@ -240,7 +240,7 @@ CREATE TABLE `order_items` (
 
 CREATE TABLE `product_custom_groups` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `product_id` int(11) unsigned NOT NULL,
+  `product_id` int(11) NOT NULL,
   `name` varchar(200) NOT NULL,
   `type` enum('single','extra','addon','component') NOT NULL DEFAULT 'extra',
   `min_qty` int(11) NOT NULL DEFAULT 0,

--- a/database/migrations/20230901_create_product_customization_tables.sql
+++ b/database/migrations/20230901_create_product_customization_tables.sql
@@ -1,7 +1,7 @@
 -- Tabelas de personalização de produtos
 CREATE TABLE IF NOT EXISTS product_custom_groups (
   id         INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  product_id INT UNSIGNED NOT NULL,
+  product_id INT(11) NOT NULL,
   name       VARCHAR(200) NOT NULL,
   type       ENUM('single','extra','addon','component') NOT NULL DEFAULT 'extra',
   min_qty    INT NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary
- update product customization migration to define product_id as INT(11) instead of unsigned
- mirror the signed product_id definition in the menu schema dump so it matches products.id

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cce38680b4832ebd0468b1c8b3dbd7