### PR TITLE
Add admin ingredient management

### DIFF
--- a/app/controllers/AdminDashboardController.php
+++ b/app/controllers/AdminDashboardController.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../core/Auth.php';
 require_once __DIR__ . '/../models/Company.php';
 require_once __DIR__ . '/../models/Category.php';
 require_once __DIR__ . '/../models/Product.php';
+require_once __DIR__ . '/../models/Ingredient.php';
 
 class AdminDashboardController extends Controller
 {
@@ -60,6 +61,8 @@ class AdminDashboardController extends Controller
     $companyId = (int)$company['id'];
     $categories = Category::listByCompany($companyId);
     $products   = Product::listByCompany($companyId);
+    $ingredientsCount = Ingredient::countByCompany($companyId);
+    $recentIngredients = Ingredient::listRecentByCompany($companyId, 8);
 
     // slug efetivo do contexto (usado para montar URLs no dashboard, ex.: botão Pedidos)
     $activeSlug = $this->currentCompanySlug() ?? $slug;
@@ -69,6 +72,8 @@ class AdminDashboardController extends Controller
       'u',
       'categories',
       'products',
+      'ingredientsCount',
+      'recentIngredients',
       'activeSlug'
     ));
   }

--- a/app/controllers/AdminIngredientController.php
+++ b/app/controllers/AdminIngredientController.php
@@ -1,0 +1,175 @@
+<?php
+require_once __DIR__ . '/../core/Controller.php';
+require_once __DIR__ . '/../core/Helpers.php';
+require_once __DIR__ . '/../core/Auth.php';
+require_once __DIR__ . '/../models/Company.php';
+require_once __DIR__ . '/../models/Product.php';
+require_once __DIR__ . '/../models/Ingredient.php';
+
+class AdminIngredientController extends Controller
+{
+  private function guard($slug)
+  {
+    Auth::start();
+    $u = Auth::user();
+    if (!$u) {
+      header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login'));
+      exit;
+    }
+
+    $company = Company::findBySlug($slug);
+    if (!$company) { echo "Empresa inválida"; exit; }
+
+    if ($u['role'] !== 'root' && (int)$u['company_id'] !== (int)$company['id']) {
+      echo "Acesso negado"; exit;
+    }
+
+    return [$u, $company];
+  }
+
+  private function consumeFlash(string $key)
+  {
+    $value = $_SESSION[$key] ?? null;
+    unset($_SESSION[$key]);
+    return $value;
+  }
+
+  public function index($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+
+    $productId = isset($_GET['product_id']) && $_GET['product_id'] !== '' ? (int)$_GET['product_id'] : null;
+    $q = isset($_GET['q']) ? trim($_GET['q']) : null;
+
+    $items = Ingredient::listByCompany($companyId, $productId, $q !== '' ? $q : null);
+    $products = Product::allForCompany($companyId);
+    $error = $this->consumeFlash('flash_error');
+
+    return $this->view('admin/ingredients/index', compact('company', 'items', 'products', 'error', 'productId', 'q'));
+  }
+
+  public function create($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+
+    $error = $this->consumeFlash('flash_error');
+    $old = $this->consumeFlash('flash_old_ingredient');
+
+    $ingredient = [
+      'id' => null,
+      'product_id' => $old['product_id'] ?? '',
+      'name' => $old['name'] ?? '',
+    ];
+
+    $products = Product::allForCompany($companyId);
+
+    return $this->view('admin/ingredients/form', compact('company', 'ingredient', 'products', 'error'));
+  }
+
+  public function store($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+
+    $productId = isset($_POST['product_id']) ? (int)$_POST['product_id'] : 0;
+    $name = trim($_POST['name'] ?? '');
+
+    $product = $productId ? Product::findByCompanyAndId($companyId, $productId) : null;
+
+    if (!$product) {
+      $_SESSION['flash_error'] = 'Selecione um produto válido.';
+      $_SESSION['flash_old_ingredient'] = ['product_id' => $productId, 'name' => $name];
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients/create'));
+      exit;
+    }
+
+    if ($name === '') {
+      $_SESSION['flash_error'] = 'Informe o nome do ingrediente.';
+      $_SESSION['flash_old_ingredient'] = ['product_id' => $productId, 'name' => $name];
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients/create'));
+      exit;
+    }
+
+    Ingredient::create([
+      'product_id' => $productId,
+      'name' => $name,
+    ]);
+
+    header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients'));
+    exit;
+  }
+
+  public function edit($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+
+    $ingredient = Ingredient::findForCompany($companyId, (int)$params['id']);
+    if (!$ingredient) { echo "Ingrediente não encontrado."; exit; }
+
+    $error = $this->consumeFlash('flash_error');
+    $old = $this->consumeFlash('flash_old_ingredient');
+
+    if ($old) {
+      $ingredient['product_id'] = $old['product_id'];
+      $ingredient['name'] = $old['name'];
+    }
+
+    $products = Product::allForCompany($companyId);
+
+    return $this->view('admin/ingredients/form', compact('company', 'ingredient', 'products', 'error'));
+  }
+
+  public function update($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+    $ingredientId = (int)$params['id'];
+
+    $ingredient = Ingredient::findForCompany($companyId, $ingredientId);
+    if (!$ingredient) { echo "Ingrediente não encontrado."; exit; }
+
+    $productId = isset($_POST['product_id']) ? (int)$_POST['product_id'] : 0;
+    $name = trim($_POST['name'] ?? '');
+
+    $product = $productId ? Product::findByCompanyAndId($companyId, $productId) : null;
+    if (!$product) {
+      $_SESSION['flash_error'] = 'Selecione um produto válido.';
+      $_SESSION['flash_old_ingredient'] = ['product_id' => $productId, 'name' => $name];
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients/' . $ingredientId . '/edit'));
+      exit;
+    }
+
+    if ($name === '') {
+      $_SESSION['flash_error'] = 'Informe o nome do ingrediente.';
+      $_SESSION['flash_old_ingredient'] = ['product_id' => $productId, 'name' => $name];
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients/' . $ingredientId . '/edit'));
+      exit;
+    }
+
+    Ingredient::update($ingredientId, [
+      'product_id' => $productId,
+      'name' => $name,
+    ]);
+
+    header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients'));
+    exit;
+  }
+
+  public function destroy($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+    $ingredientId = (int)$params['id'];
+
+    $ingredient = Ingredient::findForCompany($companyId, $ingredientId);
+    if (!$ingredient) { echo "Ingrediente não encontrado."; exit; }
+
+    Ingredient::delete($ingredientId);
+
+    header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients'));
+    exit;
+  }
+}

--- a/app/models/Ingredient.php
+++ b/app/models/Ingredient.php
@@ -1,0 +1,96 @@
+<?php
+require_once __DIR__ . '/../config/db.php';
+
+class Ingredient
+{
+  public static function listByCompany(int $companyId, ?int $productId = null, ?string $q = null): array
+  {
+    $sql = "SELECT i.*, p.name AS product_name
+              FROM ingredients i
+              INNER JOIN products p ON p.id = i.product_id
+             WHERE p.company_id = ?";
+    $args = [$companyId];
+
+    if ($productId) {
+      $sql .= " AND i.product_id = ?";
+      $args[] = $productId;
+    }
+
+    if ($q) {
+      $sql .= " AND i.name LIKE ?";
+      $args[] = '%' . $q . '%';
+    }
+
+    $sql .= " ORDER BY p.name, i.name";
+
+    $st = db()->prepare($sql);
+    $st->execute($args);
+    return $st->fetchAll(PDO::FETCH_ASSOC);
+  }
+
+  public static function listRecentByCompany(int $companyId, int $limit = 8): array
+  {
+    $sql = "SELECT i.*, p.name AS product_name
+              FROM ingredients i
+              INNER JOIN products p ON p.id = i.product_id
+             WHERE p.company_id = ?
+          ORDER BY i.id DESC
+             LIMIT ?";
+    $st = db()->prepare($sql);
+    $st->bindValue(1, $companyId, PDO::PARAM_INT);
+    $st->bindValue(2, $limit, PDO::PARAM_INT);
+    $st->execute();
+    return $st->fetchAll(PDO::FETCH_ASSOC);
+  }
+
+  public static function find(int $id): ?array
+  {
+    $st = db()->prepare("SELECT * FROM ingredients WHERE id = ?");
+    $st->execute([$id]);
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    return $row ?: null;
+  }
+
+  public static function findForCompany(int $companyId, int $ingredientId): ?array
+  {
+    $sql = "SELECT i.*, p.name AS product_name, p.company_id
+              FROM ingredients i
+              INNER JOIN products p ON p.id = i.product_id
+             WHERE i.id = ? AND p.company_id = ?";
+    $st = db()->prepare($sql);
+    $st->execute([$ingredientId, $companyId]);
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    return $row ?: null;
+  }
+
+  public static function create(array $data): int
+  {
+    $st = db()->prepare("INSERT INTO ingredients (product_id, name) VALUES (?, ?)");
+    $st->execute([$data['product_id'], $data['name']]);
+    return (int)db()->lastInsertId();
+  }
+
+  public static function update(int $id, array $data): void
+  {
+    $st = db()->prepare("UPDATE ingredients SET product_id = ?, name = ? WHERE id = ?");
+    $st->execute([$data['product_id'], $data['name'], $id]);
+  }
+
+  public static function delete(int $id): void
+  {
+    $st = db()->prepare("DELETE FROM ingredients WHERE id = ?");
+    $st->execute([$id]);
+  }
+
+  public static function countByCompany(int $companyId): int
+  {
+    $sql = "SELECT COUNT(*) AS total
+              FROM ingredients i
+              INNER JOIN products p ON p.id = i.product_id
+             WHERE p.company_id = ?";
+    $st = db()->prepare($sql);
+    $st->execute([$companyId]);
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    return (int)($row['total'] ?? 0);
+  }
+}

--- a/app/models/Product.php
+++ b/app/models/Product.php
@@ -34,6 +34,13 @@ class Product
     return $st->fetchAll(PDO::FETCH_ASSOC);
   }
 
+  public static function allForCompany(int $companyId): array {
+    $sql = "SELECT * FROM products WHERE company_id = ? ORDER BY name";
+    $st = db()->prepare($sql);
+    $st->execute([$companyId]);
+    return $st->fetchAll(PDO::FETCH_ASSOC);
+  }
+
   public static function find(int $id): ?array {
     $st = db()->prepare("SELECT * FROM products WHERE id = ?");
     $st->execute([$id]);

--- a/app/views/admin/dashboard/index.php
+++ b/app/views/admin/dashboard/index.php
@@ -25,6 +25,8 @@ ob_start(); ?>
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">🗂️ Categorias</a>
     <a href="<?= e(base_url('admin/' . $slug . '/products')) ?>"
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">🧾 Produtos</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/ingredients')) ?>"
+     class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">🥕 Ingredientes</a>
     <a href="<?= e(base_url('admin/' . $slug . '/orders')) ?>"
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">📦 Pedidos</a>
     <a href="<?= e(base_url($publicSlug)) ?>" target="_blank"
@@ -32,7 +34,7 @@ ob_start(); ?>
 </nav>
 
 <!-- Cards resumo -->
-<div class="grid md:grid-cols-3 gap-4 mb-6">
+<div class="grid md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
   <div class="rounded-2xl bg-white border p-4">
     <div class="text-sm text-gray-500 mb-1">Categorias</div>
     <div class="text-3xl font-bold mb-3"><?= count($categories) ?></div>
@@ -49,6 +51,15 @@ ob_start(); ?>
   </div>
 
   <div class="rounded-2xl bg-white border p-4">
+    <div class="text-sm text-gray-500 mb-1">Ingredientes</div>
+    <div class="text-3xl font-bold mb-3"><?= (int)$ingredientsCount ?></div>
+    <div class="flex gap-2">
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/ingredients')) ?>">Gerenciar</a>
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/ingredients/create')) ?>">+ Novo</a>
+    </div>
+  </div>
+
+  <div class="rounded-2xl bg-white border p-4">
     <div class="text-sm text-gray-500 mb-1">Pedidos</div>
     <div class="text-3xl font-bold mb-3">📦</div>
       <a class="px-3 py-2 rounded-xl border inline-block" href="<?= e(base_url('admin/' . $slug . '/orders')) ?>">Ver pedidos</a>
@@ -56,7 +67,7 @@ ob_start(); ?>
 </div>
 
 <!-- Listas rápidas -->
-<div class="grid md:grid-cols-2 gap-4">
+<div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
   <div class="rounded-2xl bg-white border p-4">
     <h2 class="font-semibold mb-2">Categorias</h2>
     <ul class="list-disc ml-5">
@@ -104,7 +115,28 @@ ob_start(); ?>
     </ul>
     <div class="mt-3 flex gap-2">
         <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products/create')) ?>">+ Novo produto</a>
-        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products')) ?>">Ver todos</a>
+      <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products')) ?>">Ver todos</a>
+    </div>
+  </div>
+
+  <div class="rounded-2xl bg-white border p-4">
+    <h2 class="font-semibold mb-2">Ingredientes recentes</h2>
+    <ul class="list-disc ml-5">
+      <?php foreach ($recentIngredients as $ing): ?>
+        <li>
+          <?= e($ing['name']) ?>
+          <?php if (!empty($ing['product_name'])): ?>
+            <span class="text-xs text-gray-500">(<?= e($ing['product_name']) ?>)</span>
+          <?php endif; ?>
+        </li>
+      <?php endforeach; ?>
+      <?php if (!count($recentIngredients)): ?>
+        <li class="text-sm text-gray-500">Sem ingredientes cadastrados.</li>
+      <?php endif; ?>
+    </ul>
+    <div class="mt-3 flex gap-2">
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/ingredients/create')) ?>">+ Novo ingrediente</a>
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/ingredients')) ?>">Ver todos</a>
     </div>
   </div>
 </div>

--- a/app/views/admin/ingredients/form.php
+++ b/app/views/admin/ingredients/form.php
@@ -1,0 +1,37 @@
+<?php
+$title = "Ingrediente - " . ($company['name'] ?? '');
+$editing = !empty($ingredient['id']);
+$slug = rawurlencode($company['slug']);
+$action = $editing ? 'admin/' . $slug . '/ingredients/' . (int)$ingredient['id'] : 'admin/' . $slug . '/ingredients';
+ob_start(); ?>
+<h1 class="text-2xl font-bold mb-4"><?= $editing ? 'Editar' : 'Novo' ?> Ingrediente</h1>
+
+<?php if (!empty($error)): ?>
+  <div class="mb-3 p-3 bg-red-100 text-red-800 rounded-xl"><?= e($error) ?></div>
+<?php endif; ?>
+
+<form method="post" action="<?= e(base_url($action)) ?>" class="grid gap-3 max-w-xl bg-white p-4 rounded-2xl border">
+  <label class="grid gap-1">
+    <span class="text-sm">Produto</span>
+    <select name="product_id" class="border rounded-xl p-2" required>
+      <option value="">Selecione</option>
+      <?php foreach ($products as $p): ?>
+        <option value="<?= (int)$p['id'] ?>" <?= (int)($ingredient['product_id'] ?? 0) === (int)$p['id'] ? 'selected' : '' ?>>
+          <?= e($p['name']) ?>
+        </option>
+      <?php endforeach; ?>
+    </select>
+  </label>
+
+  <label class="grid gap-1">
+    <span class="text-sm">Nome do ingrediente</span>
+    <input name="name" value="<?= e($ingredient['name'] ?? '') ?>" class="border rounded-xl p-2" required>
+  </label>
+
+  <div class="flex gap-2">
+    <button class="px-4 py-2 rounded-xl border">Salvar</button>
+      <a href="<?= e(base_url('admin/' . $slug . '/ingredients')) ?>" class="px-4 py-2 rounded-xl border">Cancelar</a>
+  </div>
+</form>
+<?php
+$content = ob_get_clean(); include __DIR__ . '/../layout.php';

--- a/app/views/admin/ingredients/index.php
+++ b/app/views/admin/ingredients/index.php
@@ -1,0 +1,59 @@
+<?php
+$title = "Ingredientes - " . ($company['name'] ?? '');
+$slug = rawurlencode($company['slug']);
+$selectedProduct = $productId ?? null;
+$search = $q ?? '';
+ob_start(); ?>
+<header class="flex items-center gap-3 mb-4">
+  <h1 class="text-2xl font-bold">Ingredientes</h1>
+    <a href="<?= e(base_url('admin/' . $slug . '/ingredients/create')) ?>" class="ml-auto px-3 py-2 rounded-xl border">+ Novo</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/products')) ?>" class="px-3 py-2 rounded-xl border">Produtos</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/dashboard')) ?>" class="px-3 py-2 rounded-xl border">Dashboard</a>
+</header>
+
+<?php if (!empty($error)): ?>
+  <div class="mb-3 p-3 bg-red-100 text-red-800 rounded-xl"><?= e($error) ?></div>
+<?php endif; ?>
+
+<form method="get" class="mb-4 grid gap-2 md:flex md:items-center md:gap-3">
+  <select name="product_id" class="border rounded-xl px-3 py-2">
+    <option value="">Todos os produtos</option>
+    <?php foreach ($products as $p): ?>
+      <option value="<?= (int)$p['id'] ?>" <?= $selectedProduct === (int)$p['id'] ? 'selected' : '' ?>>
+        <?= e($p['name']) ?>
+      </option>
+    <?php endforeach; ?>
+  </select>
+  <input type="text" name="q" value="<?= e($search) ?>" placeholder="Buscar por nome" class="border rounded-xl px-3 py-2 flex-1">
+  <button class="px-4 py-2 rounded-xl border bg-white">Filtrar</button>
+</form>
+
+<?php if (count($items)): ?>
+<table class="w-full bg-white border rounded-2xl overflow-hidden">
+  <thead class="bg-slate-100">
+    <tr>
+      <th class="text-left p-3">Ingrediente</th>
+      <th class="text-left p-3">Produto</th>
+      <th class="p-3"></th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($items as $item): ?>
+    <tr class="border-t">
+      <td class="p-3"><?= e($item['name']) ?></td>
+      <td class="p-3"><?= e($item['product_name'] ?? '') ?></td>
+      <td class="p-3 text-right">
+          <a class="px-3 py-1 border rounded-xl" href="<?= e(base_url('admin/' . $slug . '/ingredients/' . (int)$item['id'] . '/edit')) ?>">Editar</a>
+          <form method="post" action="<?= e(base_url('admin/' . $slug . '/ingredients/' . (int)$item['id'] . '/del')) ?>" class="inline" onsubmit="return confirm('Excluir ingrediente?');">
+          <button class="px-3 py-1 border rounded-xl">Excluir</button>
+        </form>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<?php else: ?>
+  <div class="p-4 bg-white border rounded-2xl text-sm text-gray-600">Nenhum ingrediente encontrado.</div>
+<?php endif; ?>
+<?php
+$content = ob_get_clean(); include __DIR__ . '/../layout.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,14 @@ $router->get('/admin/{slug}/products/{id}/edit',    'AdminProductController@edit
 $router->post('/admin/{slug}/products/{id}',        'AdminProductController@update');
 $router->post('/admin/{slug}/products/{id}/del',    'AdminProductController@destroy');
 
+// Ingredientes (CRUD)
+$router->get('/admin/{slug}/ingredients',              'AdminIngredientController@index');
+$router->get('/admin/{slug}/ingredients/create',       'AdminIngredientController@create');
+$router->post('/admin/{slug}/ingredients',             'AdminIngredientController@store');
+$router->get('/admin/{slug}/ingredients/{id}/edit',    'AdminIngredientController@edit');
+$router->post('/admin/{slug}/ingredients/{id}',        'AdminIngredientController@update');
+$router->post('/admin/{slug}/ingredients/{id}/del',    'AdminIngredientController@destroy');
+
 /* ========= Constraints globais ========= */
 if (method_exists($router, 'where')) {
   $router->where('slug', '[a-z0-9\-]+');


### PR DESCRIPTION
## Summary
- add Ingredient model and admin controller with CRUD endpoints for managing ingredient records
- introduce admin ingredient list and form views and wire new routes
- surface ingredient links, counts, and recent items within the dashboard overview

## Testing
- php -l app/controllers/AdminIngredientController.php
- php -l app/models/Ingredient.php
- php -l app/models/Product.php
- php -l app/controllers/AdminDashboardController.php
- php -l app/views/admin/dashboard/index.php
- php -l app/views/admin/ingredients/index.php
- php -l app/views/admin/ingredients/form.php
- php -l routes/web.php

------
https://chatgpt.com/codex/tasks/task_e_68cd8e78b4ac832eadc9411f2d263572