### PR TITLE
Prevent duplicate ingredients and selections

### DIFF
--- a/app/controllers/AdminDashboardController.php
+++ b/app/controllers/AdminDashboardController.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../core/Auth.php';
 require_once __DIR__ . '/../models/Company.php';
 require_once __DIR__ . '/../models/Category.php';
 require_once __DIR__ . '/../models/Product.php';
+require_once __DIR__ . '/../models/Ingredient.php';
 
 class AdminDashboardController extends Controller
 {
@@ -60,6 +61,13 @@ class AdminDashboardController extends Controller
     $companyId = (int)$company['id'];
     $categories = Category::listByCompany($companyId);
     $products   = Product::listByCompany($companyId);
+    $ingredientsCount = Ingredient::countByCompany($companyId);
+    $recentIngredients = Ingredient::listRecentByCompany($companyId, 8);
+    foreach ($recentIngredients as &$ing) {
+      $assigned = Ingredient::assignedProducts((int)$ing['id']);
+      $ing['product_names'] = array_column($assigned, 'name');
+    }
+    unset($ing);
 
     // slug efetivo do contexto (usado para montar URLs no dashboard, ex.: botão Pedidos)
     $activeSlug = $this->currentCompanySlug() ?? $slug;
@@ -69,6 +77,8 @@ class AdminDashboardController extends Controller
       'u',
       'categories',
       'products',
+      'ingredientsCount',
+      'recentIngredients',
       'activeSlug'
     ));
   }

--- a/app/controllers/AdminIngredientController.php
+++ b/app/controllers/AdminIngredientController.php
@@ -1,0 +1,240 @@
+<?php
+require_once __DIR__ . '/../core/Controller.php';
+require_once __DIR__ . '/../core/Helpers.php';
+require_once __DIR__ . '/../core/Auth.php';
+require_once __DIR__ . '/../models/Company.php';
+require_once __DIR__ . '/../models/Product.php';
+require_once __DIR__ . '/../models/Ingredient.php';
+
+class AdminIngredientController extends Controller
+{
+  private function guard($slug)
+  {
+    Auth::start();
+    $u = Auth::user();
+    if (!$u) {
+      header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login'));
+      exit;
+    }
+
+    $company = Company::findBySlug($slug);
+    if (!$company) { echo "Empresa inválida"; exit; }
+
+    if ($u['role'] !== 'root' && (int)$u['company_id'] !== (int)$company['id']) {
+      echo "Acesso negado"; exit;
+    }
+
+    return [$u, $company];
+  }
+
+  private function consumeFlash(string $key)
+  {
+    $value = $_SESSION[$key] ?? null;
+    unset($_SESSION[$key]);
+    return $value;
+  }
+
+  public function index($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+
+    $productId = isset($_GET['product_id']) && $_GET['product_id'] !== '' ? (int)$_GET['product_id'] : null;
+    $q = isset($_GET['q']) ? trim($_GET['q']) : null;
+
+    $items = Ingredient::listByCompany($companyId, $productId, $q !== '' ? $q : null);
+    $products = Product::allForCompany($companyId);
+    $error = $this->consumeFlash('flash_error');
+
+    return $this->view('admin/ingredients/index', compact('company', 'items', 'products', 'error', 'productId', 'q'));
+  }
+
+  public function create($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+
+    $error = $this->consumeFlash('flash_error');
+    $old = $this->consumeFlash('flash_old_ingredient');
+
+    $ingredient = [
+      'id' => null,
+      'name' => $old['name'] ?? '',
+      'min_qty' => $old['min_qty'] ?? 0,
+      'max_qty' => $old['max_qty'] ?? 1,
+      'image_path' => null,
+    ];
+
+    return $this->view('admin/ingredients/form', compact('company', 'ingredient', 'error'));
+  }
+
+  public function store($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+
+    $name = trim($_POST['name'] ?? '');
+    $min = isset($_POST['min_qty']) ? max(0, (int)$_POST['min_qty']) : 0;
+    $max = isset($_POST['max_qty']) ? max(0, (int)$_POST['max_qty']) : 1;
+    if ($max < $min) {
+      $max = $min;
+    }
+
+    [$imagePath, $uploadError] = $this->handleUpload($_FILES['image'] ?? null);
+
+    if ($name === '') {
+      $_SESSION['flash_error'] = 'Informe o nome do ingrediente.';
+      $_SESSION['flash_old_ingredient'] = ['name' => $name, 'min_qty' => $min, 'max_qty' => $max];
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients/create'));
+      exit;
+    }
+
+    if (Ingredient::existsByName($companyId, $name)) {
+      $_SESSION['flash_error'] = 'Já existe um ingrediente com este nome.';
+      $_SESSION['flash_old_ingredient'] = ['name' => $name, 'min_qty' => $min, 'max_qty' => $max];
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients/create'));
+      exit;
+    }
+
+    if ($uploadError) {
+      $_SESSION['flash_error'] = $uploadError;
+      $_SESSION['flash_old_ingredient'] = ['name' => $name, 'min_qty' => $min, 'max_qty' => $max];
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients/create'));
+      exit;
+    }
+
+    Ingredient::create([
+      'company_id' => $companyId,
+      'name' => $name,
+      'min_qty' => $min,
+      'max_qty' => $max,
+      'image_path' => $imagePath,
+    ]);
+
+    header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients'));
+    exit;
+  }
+
+  public function edit($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+
+    $ingredient = Ingredient::findForCompany($companyId, (int)$params['id']);
+    if (!$ingredient) { echo "Ingrediente não encontrado."; exit; }
+
+    $error = $this->consumeFlash('flash_error');
+    $old = $this->consumeFlash('flash_old_ingredient');
+
+    if ($old) {
+      $ingredient['name'] = $old['name'];
+      $ingredient['min_qty'] = $old['min_qty'];
+      $ingredient['max_qty'] = $old['max_qty'];
+    }
+
+    return $this->view('admin/ingredients/form', compact('company', 'ingredient', 'error'));
+  }
+
+  public function update($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+    $ingredientId = (int)$params['id'];
+
+    $ingredient = Ingredient::findForCompany($companyId, $ingredientId);
+    if (!$ingredient) { echo "Ingrediente não encontrado."; exit; }
+
+    $name = trim($_POST['name'] ?? '');
+    $min = isset($_POST['min_qty']) ? max(0, (int)$_POST['min_qty']) : 0;
+    $max = isset($_POST['max_qty']) ? max(0, (int)$_POST['max_qty']) : 1;
+    if ($max < $min) {
+      $max = $min;
+    }
+
+    [$imagePath, $uploadError] = $this->handleUpload($_FILES['image'] ?? null, $ingredient['image_path'] ?? null);
+
+    if ($name === '') {
+      $_SESSION['flash_error'] = 'Informe o nome do ingrediente.';
+      $_SESSION['flash_old_ingredient'] = ['name' => $name, 'min_qty' => $min, 'max_qty' => $max];
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients/' . $ingredientId . '/edit'));
+      exit;
+    }
+
+    if (Ingredient::existsByName($companyId, $name, $ingredientId)) {
+      $_SESSION['flash_error'] = 'Já existe um ingrediente com este nome.';
+      $_SESSION['flash_old_ingredient'] = ['name' => $name, 'min_qty' => $min, 'max_qty' => $max];
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients/' . $ingredientId . '/edit'));
+      exit;
+    }
+
+    if ($uploadError) {
+      $_SESSION['flash_error'] = $uploadError;
+      $_SESSION['flash_old_ingredient'] = ['name' => $name, 'min_qty' => $min, 'max_qty' => $max];
+      header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients/' . $ingredientId . '/edit'));
+      exit;
+    }
+
+    Ingredient::update($ingredientId, [
+      'name' => $name,
+      'min_qty' => $min,
+      'max_qty' => $max,
+      'image_path' => $imagePath,
+    ]);
+
+    header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients'));
+    exit;
+  }
+
+  public function destroy($params)
+  {
+    [$u, $company] = $this->guard($params['slug']);
+    $companyId = (int)$company['id'];
+    $ingredientId = (int)$params['id'];
+
+    $ingredient = Ingredient::findForCompany($companyId, $ingredientId);
+    if (!$ingredient) { echo "Ingrediente não encontrado."; exit; }
+
+    Ingredient::delete($companyId, $ingredientId);
+
+    header('Location: ' . base_url('admin/' . rawurlencode($company['slug']) . '/ingredients'));
+    exit;
+  }
+
+  private function handleUpload(?array $file, ?string $current = null): array
+  {
+    if (!$file || ($file['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_NO_FILE) {
+      return [$current, null];
+    }
+
+    if (($file['error'] ?? UPLOAD_ERR_OK) !== UPLOAD_ERR_OK) {
+      return [$current, 'Falha ao enviar a imagem (código ' . $file['error'] . ').'];
+    }
+
+    $ext = strtolower(pathinfo($file['name'] ?? '', PATHINFO_EXTENSION));
+    if (!in_array($ext, ['jpg','jpeg','png','webp'], true)) {
+      return [$current, 'Formato inválido. Use JPG, PNG ou WEBP.'];
+    }
+
+    $name = 'ingredient_' . time() . '_' . rand(1000, 9999) . '.' . $ext;
+    $dest = __DIR__ . '/../../public/uploads/' . $name;
+    $dir = dirname($dest);
+
+    if (!is_dir($dir) && !mkdir($dir, 0777, true)) {
+      return [$current, 'Não foi possível criar o diretório de uploads.'];
+    }
+
+    if (!is_writable($dir)) {
+      return [$current, 'Diretório de uploads sem permissão de escrita.'];
+    }
+
+    if (!is_uploaded_file($file['tmp_name'] ?? '')) {
+      return [$current, 'Arquivo inválido.'];
+    }
+
+    if (!move_uploaded_file($file['tmp_name'], $dest)) {
+      return [$current, 'Não foi possível salvar o arquivo enviado.'];
+    }
+
+    return ['uploads/' . $name, null];
+  }
+}

--- a/app/controllers/AdminProductController.php
+++ b/app/controllers/AdminProductController.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../core/Auth.php';
 require_once __DIR__ . '/../models/Company.php';
 require_once __DIR__ . '/../models/Category.php';
 require_once __DIR__ . '/../models/Product.php';
+require_once __DIR__ . '/../models/Ingredient.php';
 require_once __DIR__ . '/../models/ProductCustomization.php';
 
 class AdminProductController extends Controller {
@@ -58,7 +59,8 @@ class AdminProductController extends Controller {
     ];
 
     $customization = ['enabled' => false, 'groups' => []];
-    return $this->view('admin/products/form', compact('company','cats','p','customization'));
+    $ingredients = Ingredient::allForCompany((int)$company['id']);
+    return $this->view('admin/products/form', compact('company','cats','p','customization','ingredients'));
   }
 
   /**
@@ -122,7 +124,7 @@ class AdminProductController extends Controller {
     if ($imgError) $_SESSION['flash_error'] = $imgError;
 
     $custPayload = $_POST['customization'] ?? [];
-    $custData    = ProductCustomization::sanitizePayload(is_array($custPayload) ? $custPayload : []);
+    $custData    = ProductCustomization::sanitizePayload(is_array($custPayload) ? $custPayload : [], (int)$company['id']);
 
     $data = [
       'company_id'  => (int)$company['id'],
@@ -156,8 +158,9 @@ class AdminProductController extends Controller {
       'enabled' => !empty($p['allow_customize']),
       'groups'  => ProductCustomization::loadForAdmin((int)$p['id']),
     ];
+    $ingredients = Ingredient::allForCompany((int)$company['id']);
 
-    return $this->view('admin/products/form', compact('company','cats','p','customization'));
+    return $this->view('admin/products/form', compact('company','cats','p','customization','ingredients'));
   } // <-- ESTA CHAVE FALTAVA
 
   /** Persistência da edição */
@@ -172,7 +175,7 @@ class AdminProductController extends Controller {
     if ($imgError) $_SESSION['flash_error'] = $imgError;
 
     $custPayload = $_POST['customization'] ?? [];
-    $custData    = ProductCustomization::sanitizePayload(is_array($custPayload) ? $custPayload : []);
+    $custData    = ProductCustomization::sanitizePayload(is_array($custPayload) ? $custPayload : [], (int)$company['id']);
 
     $data = [
       'category_id' => $_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null,

--- a/app/models/Ingredient.php
+++ b/app/models/Ingredient.php
@@ -1,0 +1,163 @@
+<?php
+
+require_once __DIR__ . '/../config/db.php';
+
+class Ingredient
+{
+  public static function listByCompany(int $companyId, ?int $productId = null, ?string $q = null): array
+  {
+    $pdo = db();
+
+    $sql = "SELECT i.*, GROUP_CONCAT(DISTINCT p.name ORDER BY p.name SEPARATOR '||') AS product_names
+              FROM ingredients i
+         LEFT JOIN product_custom_items  pci ON pci.ingredient_id = i.id
+         LEFT JOIN product_custom_groups pcg ON pcg.id = pci.group_id
+         LEFT JOIN products p ON p.id = pcg.product_id AND p.company_id = :company
+             WHERE i.company_id = :company";
+
+    $params = ['company' => $companyId];
+
+    if ($productId) {
+      $sql .= " AND EXISTS (
+                  SELECT 1
+                    FROM product_custom_items pci2
+                    JOIN product_custom_groups pcg2 ON pcg2.id = pci2.group_id
+                   WHERE pci2.ingredient_id = i.id
+                     AND pcg2.product_id = :productId
+                )";
+      $params['productId'] = $productId;
+    }
+
+    if ($q !== null && $q !== '') {
+      $sql .= " AND i.name LIKE :q";
+      $params['q'] = '%' . $q . '%';
+    }
+
+    $sql .= " GROUP BY i.id
+              ORDER BY i.name";
+
+    $st = $pdo->prepare($sql);
+    $st->execute($params);
+    return $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
+  }
+
+  public static function existsByName(int $companyId, string $name, ?int $ignoreId = null): bool
+  {
+    $pdo = db();
+    $sql = 'SELECT id FROM ingredients WHERE company_id = ? AND LOWER(name) = LOWER(?)';
+    $params = [$companyId, $name];
+
+    if ($ignoreId) {
+      $sql .= ' AND id <> ?';
+      $params[] = $ignoreId;
+    }
+
+    $st = $pdo->prepare($sql . ' LIMIT 1');
+    $st->execute($params);
+    return (bool)$st->fetchColumn();
+  }
+
+  public static function listRecentByCompany(int $companyId, int $limit = 8): array
+  {
+    $pdo = db();
+    $sql = "SELECT * FROM ingredients WHERE company_id = ? ORDER BY updated_at DESC LIMIT ?";
+    $st = $pdo->prepare($sql);
+    $st->bindValue(1, $companyId, PDO::PARAM_INT);
+    $st->bindValue(2, $limit, PDO::PARAM_INT);
+    $st->execute();
+    return $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
+  }
+
+  public static function countByCompany(int $companyId): int
+  {
+    $pdo = db();
+    $st = $pdo->prepare('SELECT COUNT(*) AS total FROM ingredients WHERE company_id = ?');
+    $st->execute([$companyId]);
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    return (int)($row['total'] ?? 0);
+  }
+
+  public static function allForCompany(int $companyId): array
+  {
+    $pdo = db();
+    $st = $pdo->prepare('SELECT * FROM ingredients WHERE company_id = ? ORDER BY name');
+    $st->execute([$companyId]);
+    return $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
+  }
+
+  public static function find(int $id): ?array
+  {
+    $pdo = db();
+    $st = $pdo->prepare('SELECT * FROM ingredients WHERE id = ?');
+    $st->execute([$id]);
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    return $row ?: null;
+  }
+
+  public static function findForCompany(int $companyId, int $ingredientId): ?array
+  {
+    $pdo = db();
+    $st = $pdo->prepare('SELECT * FROM ingredients WHERE id = ? AND company_id = ?');
+    $st->execute([$ingredientId, $companyId]);
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    return $row ?: null;
+  }
+
+  public static function create(array $data): int
+  {
+    $pdo = db();
+    $st = $pdo->prepare('INSERT INTO ingredients (company_id, name, min_qty, max_qty, image_path) VALUES (?,?,?,?,?)');
+    $st->execute([
+      $data['company_id'],
+      $data['name'],
+      $data['min_qty'],
+      $data['max_qty'],
+      $data['image_path'] ?? null,
+    ]);
+    return (int)$pdo->lastInsertId();
+  }
+
+  public static function update(int $id, array $data): void
+  {
+    $pdo = db();
+    $st = $pdo->prepare('UPDATE ingredients SET name = ?, min_qty = ?, max_qty = ?, image_path = ?, updated_at = NOW() WHERE id = ?');
+    $st->execute([
+      $data['name'],
+      $data['min_qty'],
+      $data['max_qty'],
+      $data['image_path'] ?? null,
+      $id,
+    ]);
+  }
+
+  public static function delete(int $companyId, int $ingredientId): void
+  {
+    $pdo = db();
+    $pdo->beginTransaction();
+    try {
+      $pdo->prepare('DELETE pci FROM product_custom_items pci WHERE pci.ingredient_id = ?')
+          ->execute([$ingredientId]);
+      $pdo->prepare('DELETE FROM ingredients WHERE id = ? AND company_id = ?')
+          ->execute([$ingredientId, $companyId]);
+      $pdo->commit();
+    } catch (Throwable $e) {
+      $pdo->rollBack();
+      throw $e;
+    }
+  }
+
+  public static function assignedProducts(int $ingredientId): array
+  {
+    $pdo = db();
+    $sql = "SELECT DISTINCT p.id, p.name
+              FROM product_custom_items pci
+              JOIN product_custom_groups pcg ON pcg.id = pci.group_id
+              JOIN products p ON p.id = pcg.product_id
+              JOIN ingredients i ON i.id = pci.ingredient_id
+             WHERE pci.ingredient_id = ? AND p.company_id = i.company_id
+          ORDER BY p.name";
+    $st = $pdo->prepare($sql);
+    $st->execute([$ingredientId]);
+    return $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
+  }
+}

--- a/app/models/Product.php
+++ b/app/models/Product.php
@@ -34,6 +34,13 @@ class Product
     return $st->fetchAll(PDO::FETCH_ASSOC);
   }
 
+  public static function allForCompany(int $companyId): array {
+    $sql = "SELECT * FROM products WHERE company_id = ? ORDER BY name";
+    $st = db()->prepare($sql);
+    $st->execute([$companyId]);
+    return $st->fetchAll(PDO::FETCH_ASSOC);
+  }
+
   public static function find(int $id): ?array {
     $st = db()->prepare("SELECT * FROM products WHERE id = ?");
     $st->execute([$id]);

--- a/app/views/admin/dashboard/index.php
+++ b/app/views/admin/dashboard/index.php
@@ -25,6 +25,8 @@ ob_start(); ?>
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">🗂️ Categorias</a>
     <a href="<?= e(base_url('admin/' . $slug . '/products')) ?>"
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">🧾 Produtos</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/ingredients')) ?>"
+     class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">🥕 Ingredientes</a>
     <a href="<?= e(base_url('admin/' . $slug . '/orders')) ?>"
      class="px-3 py-2 rounded-xl border bg-white hover:bg-slate-50">📦 Pedidos</a>
     <a href="<?= e(base_url($publicSlug)) ?>" target="_blank"
@@ -32,7 +34,7 @@ ob_start(); ?>
 </nav>
 
 <!-- Cards resumo -->
-<div class="grid md:grid-cols-3 gap-4 mb-6">
+<div class="grid md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
   <div class="rounded-2xl bg-white border p-4">
     <div class="text-sm text-gray-500 mb-1">Categorias</div>
     <div class="text-3xl font-bold mb-3"><?= count($categories) ?></div>
@@ -49,6 +51,15 @@ ob_start(); ?>
   </div>
 
   <div class="rounded-2xl bg-white border p-4">
+    <div class="text-sm text-gray-500 mb-1">Ingredientes</div>
+    <div class="text-3xl font-bold mb-3"><?= (int)$ingredientsCount ?></div>
+    <div class="flex gap-2">
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/ingredients')) ?>">Gerenciar</a>
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/ingredients/create')) ?>">+ Novo</a>
+    </div>
+  </div>
+
+  <div class="rounded-2xl bg-white border p-4">
     <div class="text-sm text-gray-500 mb-1">Pedidos</div>
     <div class="text-3xl font-bold mb-3">📦</div>
       <a class="px-3 py-2 rounded-xl border inline-block" href="<?= e(base_url('admin/' . $slug . '/orders')) ?>">Ver pedidos</a>
@@ -56,7 +67,7 @@ ob_start(); ?>
 </div>
 
 <!-- Listas rápidas -->
-<div class="grid md:grid-cols-2 gap-4">
+<div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
   <div class="rounded-2xl bg-white border p-4">
     <h2 class="font-semibold mb-2">Categorias</h2>
     <ul class="list-disc ml-5">
@@ -104,7 +115,28 @@ ob_start(); ?>
     </ul>
     <div class="mt-3 flex gap-2">
         <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products/create')) ?>">+ Novo produto</a>
-        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products')) ?>">Ver todos</a>
+      <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/products')) ?>">Ver todos</a>
+    </div>
+  </div>
+
+  <div class="rounded-2xl bg-white border p-4">
+    <h2 class="font-semibold mb-2">Ingredientes recentes</h2>
+    <ul class="list-disc ml-5">
+      <?php foreach ($recentIngredients as $ing): ?>
+        <li>
+          <?= e($ing['name']) ?>
+          <?php if (!empty($ing['product_names'])): ?>
+            <span class="text-xs text-gray-500">(<?= e(implode(', ', (array)$ing['product_names'])) ?>)</span>
+          <?php endif; ?>
+        </li>
+      <?php endforeach; ?>
+      <?php if (!count($recentIngredients)): ?>
+        <li class="text-sm text-gray-500">Sem ingredientes cadastrados.</li>
+      <?php endif; ?>
+    </ul>
+    <div class="mt-3 flex gap-2">
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/ingredients/create')) ?>">+ Novo ingrediente</a>
+        <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/ingredients')) ?>">Ver todos</a>
     </div>
   </div>
 </div>

--- a/app/views/admin/ingredients/form.php
+++ b/app/views/admin/ingredients/form.php
@@ -1,0 +1,53 @@
+<?php
+$title = "Ingrediente - " . ($company['name'] ?? '');
+$editing = !empty($ingredient['id']);
+$slug = rawurlencode($company['slug']);
+$action = $editing ? 'admin/' . $slug . '/ingredients/' . (int)$ingredient['id'] : 'admin/' . $slug . '/ingredients';
+$image = $ingredient['image_path'] ?? null;
+ob_start(); ?>
+<h1 class="text-2xl font-bold mb-4"><?= $editing ? 'Editar' : 'Novo' ?> Ingrediente</h1>
+
+<?php if (!empty($error)): ?>
+  <div class="mb-3 p-3 bg-red-100 text-red-800 rounded-xl"><?= e($error) ?></div>
+<?php endif; ?>
+
+<form method="post" enctype="multipart/form-data" action="<?= e(base_url($action)) ?>" class="grid gap-3 max-w-xl bg-white p-4 rounded-2xl border">
+  <label class="grid gap-1">
+    <span class="text-sm">Nome do ingrediente</span>
+    <input name="name" value="<?= e($ingredient['name'] ?? '') ?>" class="border rounded-xl p-2" required>
+  </label>
+
+  <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+    <label class="grid gap-1">
+      <span class="text-sm">Quantidade mínima</span>
+      <input type="number" min="0" name="min_qty" value="<?= (int)($ingredient['min_qty'] ?? 0) ?>" class="border rounded-xl p-2" required>
+    </label>
+    <label class="grid gap-1">
+      <span class="text-sm">Quantidade máxima</span>
+      <input type="number" min="1" name="max_qty" value="<?= (int)($ingredient['max_qty'] ?? 1) ?>" class="border rounded-xl p-2" required>
+    </label>
+  </div>
+
+  <div class="grid gap-2">
+    <span class="text-sm">Foto</span>
+    <div class="flex items-center gap-3">
+      <label class="inline-flex items-center px-3 py-2 border rounded-xl cursor-pointer bg-slate-50 hover:bg-slate-100">
+        <input type="file" name="image" accept="image/*" class="hidden">
+        <span>Enviar imagem</span>
+      </label>
+      <?php if ($image): ?>
+        <img src="<?= e(base_url($image)) ?>" alt="" class="w-14 h-14 rounded-full object-cover border">
+      <?php else: ?>
+        <span class="text-xs text-slate-500">Sem imagem</span>
+      <?php endif; ?>
+    </div>
+    <p class="text-xs text-slate-500">Formatos aceitos: JPG, PNG ou WEBP.</p>
+  </div>
+
+  <div class="flex gap-2">
+    <button class="px-4 py-2 rounded-xl border">Salvar</button>
+      <a href="<?= e(base_url('admin/' . $slug . '/ingredients')) ?>" class="px-4 py-2 rounded-xl border">Cancelar</a>
+  </div>
+</form>
+<?php
+$content = ob_get_clean(); include __DIR__ . '/../layout.php';

--- a/app/views/admin/ingredients/index.php
+++ b/app/views/admin/ingredients/index.php
@@ -1,0 +1,88 @@
+<?php
+$title = "Ingredientes - " . ($company['name'] ?? '');
+$slug = rawurlencode($company['slug']);
+$selectedProduct = $productId ?? null;
+$search = $q ?? '';
+ob_start(); ?>
+<header class="flex items-center gap-3 mb-4">
+  <h1 class="text-2xl font-bold">Ingredientes</h1>
+    <a href="<?= e(base_url('admin/' . $slug . '/ingredients/create')) ?>" class="ml-auto px-3 py-2 rounded-xl border">+ Novo</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/products')) ?>" class="px-3 py-2 rounded-xl border">Produtos</a>
+    <a href="<?= e(base_url('admin/' . $slug . '/dashboard')) ?>" class="px-3 py-2 rounded-xl border">Dashboard</a>
+</header>
+
+<?php if (!empty($error)): ?>
+  <div class="mb-3 p-3 bg-red-100 text-red-800 rounded-xl"><?= e($error) ?></div>
+<?php endif; ?>
+
+<form method="get" class="mb-4 grid gap-2 md:flex md:items-center md:gap-3">
+  <select name="product_id" class="border rounded-xl px-3 py-2">
+    <option value="">Todos os produtos</option>
+    <?php foreach ($products as $p): ?>
+      <option value="<?= (int)$p['id'] ?>" <?= $selectedProduct === (int)$p['id'] ? 'selected' : '' ?>>
+        <?= e($p['name']) ?>
+      </option>
+    <?php endforeach; ?>
+  </select>
+  <input type="text" name="q" value="<?= e($search) ?>" placeholder="Buscar por nome" class="border rounded-xl px-3 py-2 flex-1">
+  <button class="px-4 py-2 rounded-xl border bg-white">Filtrar</button>
+</form>
+
+<?php if (count($items)): ?>
+<table class="w-full bg-white border rounded-2xl overflow-hidden">
+  <thead class="bg-slate-100">
+    <tr>
+      <th class="text-left p-3">Ingrediente</th>
+      <th class="text-left p-3">Mín / Máx</th>
+      <th class="text-left p-3">Produtos</th>
+      <th class="p-3"></th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($items as $item): ?>
+    <tr class="border-t">
+      <td class="p-3">
+        <div class="flex items-center gap-3">
+          <?php if (!empty($item['image_path'])): ?>
+            <img src="<?= e(base_url($item['image_path'])) ?>" alt="" class="w-10 h-10 rounded-full object-cover">
+          <?php else: ?>
+            <div class="w-10 h-10 rounded-full bg-slate-200 grid place-items-center text-slate-500 text-xs">IMG</div>
+          <?php endif; ?>
+          <div>
+            <div class="font-medium"><?= e($item['name']) ?></div>
+            <?php $created = !empty($item['created_at']) ? date('d/m/Y', strtotime($item['created_at'])) : null; ?>
+            <?php if ($created): ?>
+              <div class="text-xs text-slate-500">Criado em <?= e($created) ?></div>
+            <?php endif; ?>
+          </div>
+        </div>
+      </td>
+      <td class="p-3">
+        <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">Mín <?= (int)($item['min_qty'] ?? 0) ?> · Máx <?= (int)($item['max_qty'] ?? 0) ?></span>
+      </td>
+      <td class="p-3">
+        <?php if (!empty($item['product_names'])): ?>
+          <div class="flex flex-wrap gap-1">
+            <?php foreach (explode('||', $item['product_names']) as $prodName): $prodName = trim($prodName); if ($prodName === '') continue; ?>
+              <span class="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-1 text-xs text-amber-700"><?= e($prodName) ?></span>
+            <?php endforeach; ?>
+          </div>
+        <?php else: ?>
+          <span class="text-xs text-slate-400">Não vinculado</span>
+        <?php endif; ?>
+      </td>
+      <td class="p-3 text-right">
+          <a class="px-3 py-1 border rounded-xl" href="<?= e(base_url('admin/' . $slug . '/ingredients/' . (int)$item['id'] . '/edit')) ?>">Editar</a>
+          <form method="post" action="<?= e(base_url('admin/' . $slug . '/ingredients/' . (int)$item['id'] . '/del')) ?>" class="inline" onsubmit="return confirm('Excluir ingrediente?');">
+          <button class="px-3 py-1 border rounded-xl">Excluir</button>
+        </form>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<?php else: ?>
+  <div class="p-4 bg-white border rounded-2xl text-sm text-gray-600">Nenhum ingrediente encontrado.</div>
+<?php endif; ?>
+<?php
+$content = ob_get_clean(); include __DIR__ . '/../layout.php';

--- a/app/views/public/customization.php
+++ b/app/views/public/customization.php
@@ -201,7 +201,7 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
               $img   = $it['img'] ?? null;
               $min   = isset($it['min']) ? (int)$it['min'] : 0;
               $max   = isset($it['max']) ? (int)$it['max'] : 5;
-              $qty   = isset($it['qty']) ? (int)$it['qty'] : (!empty($it['default']) ? 1 : 0);
+              $qty   = isset($it['qty']) ? (int)$it['qty'] : (!empty($it['default']) ? (int)($it['default_qty'] ?? $min) : $min);
               $delta = (float)($it['delta'] ?? 0);
             ?>
               <div class="row" data-id="<?= (int)$ii ?>" data-min="<?= $min ?>" data-max="<?= $max ?>">

--- a/database/menu_schema_with_customization.sql
+++ b/database/menu_schema_with_customization.sql
@@ -12,30 +12,16 @@ START TRANSACTION;
 SET time_zone = "+00:00";
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
- /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
- //*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
- //*!40101 SET NAMES utf8mb4 */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
 
 --
 -- Banco de dados: `menu`
 --
 
 -- --------------------------------------------------------
--- Tabela: categories
--- --------------------------------------------------------
-CREATE TABLE `categories` (
-  `id` int(11) NOT NULL,
-  `company_id` int(11) NOT NULL,
-  `name` varchar(150) NOT NULL,
-  `sort_order` int(11) NOT NULL DEFAULT 0,
-  `active` tinyint(1) NOT NULL DEFAULT 1
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-
-INSERT INTO `categories` (`id`, `company_id`, `name`, `sort_order`, `active`) VALUES
-(1, 1, 'herick', 0, 1);
-
--- --------------------------------------------------------
--- Tabela: companies
+-- Estrutura da tabela `companies`
 -- --------------------------------------------------------
 CREATE TABLE `companies` (
   `id` int(11) NOT NULL,
@@ -57,7 +43,21 @@ INSERT INTO `companies` (`id`, `slug`, `name`, `whatsapp`, `address`, `highlight
 (1, 'wollburger', 'Wollburger', '55', '', '', NULL, NULL, NULL, NULL, NULL, 1, '2025-09-11 01:38:16');
 
 -- --------------------------------------------------------
--- Tabela: company_hours
+-- Estrutura da tabela `categories`
+-- --------------------------------------------------------
+CREATE TABLE `categories` (
+  `id` int(11) NOT NULL,
+  `company_id` int(11) NOT NULL,
+  `name` varchar(150) NOT NULL,
+  `sort_order` int(11) NOT NULL DEFAULT 0,
+  `active` tinyint(1) NOT NULL DEFAULT 1
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT INTO `categories` (`id`, `company_id`, `name`, `sort_order`, `active`) VALUES
+(1, 1, 'herick', 0, 1);
+
+-- --------------------------------------------------------
+-- Estrutura da tabela `company_hours`
 -- --------------------------------------------------------
 CREATE TABLE `company_hours` (
   `id` int(11) NOT NULL,
@@ -80,7 +80,7 @@ INSERT INTO `company_hours` (`id`, `company_id`, `weekday`, `is_open`, `open1`, 
 (7, 1, 7, 0, NULL, NULL, NULL, NULL);
 
 -- --------------------------------------------------------
--- Tabela: customers
+-- Estrutura da tabela `customers`
 -- --------------------------------------------------------
 CREATE TABLE `customers` (
   `id` int(11) NOT NULL,
@@ -94,7 +94,7 @@ CREATE TABLE `customers` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
--- Tabela: orders
+-- Estrutura da tabela `orders`
 -- --------------------------------------------------------
 CREATE TABLE `orders` (
   `id` int(11) NOT NULL,
@@ -111,7 +111,7 @@ CREATE TABLE `orders` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
--- Tabela: products
+-- Estrutura da tabela `products`
 -- --------------------------------------------------------
 CREATE TABLE `products` (
   `id` int(11) NOT NULL,
@@ -137,16 +137,7 @@ INSERT INTO `products` (`id`, `company_id`, `category_id`, `name`, `description`
 (1, 1, 1, 'herick', 'herick', 10.00, NULL, NULL, NULL, 'simple', 'fixed', 0, 1, 1, '2025-09-11 01:58:33', NULL, NULL);
 
 -- --------------------------------------------------------
--- Tabela: ingredients
--- --------------------------------------------------------
-CREATE TABLE `ingredients` (
-  `id` int(11) NOT NULL,
-  `product_id` int(11) NOT NULL,
-  `name` varchar(150) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-
--- --------------------------------------------------------
--- Tabela: combo_groups
+-- Estrutura da tabela `combo_groups`
 -- --------------------------------------------------------
 CREATE TABLE `combo_groups` (
   `id` int(11) NOT NULL,
@@ -161,7 +152,7 @@ CREATE TABLE `combo_groups` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
--- Tabela: combo_group_items
+-- Estrutura da tabela `combo_group_items`
 -- --------------------------------------------------------
 CREATE TABLE `combo_group_items` (
   `id` int(11) NOT NULL,
@@ -175,7 +166,7 @@ CREATE TABLE `combo_group_items` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
--- Tabela: order_items
+-- Estrutura da tabela `order_items`
 -- --------------------------------------------------------
 CREATE TABLE `order_items` (
   `id` int(11) NOT NULL,
@@ -187,36 +178,50 @@ CREATE TABLE `order_items` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
--- Tabela: product_custom_groups  (SEM FK inline)
+-- Estrutura da tabela `ingredients`
+-- --------------------------------------------------------
+CREATE TABLE `ingredients` (
+  `id` int(11) NOT NULL,
+  `company_id` int(11) NOT NULL,
+  `name` varchar(200) NOT NULL,
+  `min_qty` int(11) NOT NULL DEFAULT 0,
+  `max_qty` int(11) NOT NULL DEFAULT 1,
+  `image_path` varchar(255) DEFAULT NULL,
+  `created_at` datetime DEFAULT current_timestamp(),
+  `updated_at` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+-- Estrutura da tabela `product_custom_groups`
 -- --------------------------------------------------------
 CREATE TABLE `product_custom_groups` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL,
   `product_id` int(11) NOT NULL,
   `name` varchar(200) NOT NULL,
   `type` enum('single','extra','addon','component') NOT NULL DEFAULT 'extra',
   `min_qty` int(11) NOT NULL DEFAULT 0,
   `max_qty` int(11) NOT NULL DEFAULT 99,
-  `sort_order` int(11) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`id`),
-  KEY `pcg_product_idx` (`product_id`)
+  `sort_order` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
--- Tabela: product_custom_items (SEM FK inline)
+-- Estrutura da tabela `product_custom_items`
 -- --------------------------------------------------------
 CREATE TABLE `product_custom_items` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL,
   `group_id` int(11) NOT NULL,
+  `ingredient_id` int(11) DEFAULT NULL,
   `label` varchar(200) NOT NULL,
   `delta` decimal(10,2) NOT NULL DEFAULT 0.00,
   `is_default` tinyint(1) NOT NULL DEFAULT 0,
-  `sort_order` int(11) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`id`),
-  KEY `pci_group_idx` (`group_id`)
+  `default_qty` int(11) NOT NULL DEFAULT 1,
+  `min_qty` int(11) NOT NULL DEFAULT 0,
+  `max_qty` int(11) NOT NULL DEFAULT 1,
+  `sort_order` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
--- Tabela: users
+-- Estrutura da tabela `users`
 -- --------------------------------------------------------
 CREATE TABLE `users` (
   `id` int(11) NOT NULL,
@@ -235,16 +240,15 @@ INSERT INTO `users` (`id`, `company_id`, `name`, `email`, `password_hash`, `role
 (3, 1, 'Atendente 1', 'staff1@wollburger.local', '$2y$10$2LxL1b0Jr3m6y8oE0EJk2uYw7s5qf7o8x7mY4O1mF0b4oE2Y5eTZu', 'staff', 1, '2025-09-11 01:49:38');
 
 -- --------------------------------------------------------
--- ÍNDICES
+-- Índices para tabelas despejadas
 -- --------------------------------------------------------
+ALTER TABLE `companies`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `slug` (`slug`);
 
 ALTER TABLE `categories`
   ADD PRIMARY KEY (`id`),
   ADD KEY `company_id` (`company_id`);
-
-ALTER TABLE `companies`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `slug` (`slug`);
 
 ALTER TABLE `company_hours`
   ADD PRIMARY KEY (`id`),
@@ -263,10 +267,6 @@ ALTER TABLE `products`
   ADD KEY `company_id` (`company_id`),
   ADD KEY `category_id` (`category_id`);
 
-ALTER TABLE `ingredients`
-  ADD PRIMARY KEY (`id`),
-  ADD KEY `product_id` (`product_id`);
-
 ALTER TABLE `combo_groups`
   ADD PRIMARY KEY (`id`),
   ADD KEY `product_id` (`product_id`);
@@ -281,11 +281,18 @@ ALTER TABLE `order_items`
   ADD KEY `order_id` (`order_id`),
   ADD KEY `product_id` (`product_id`);
 
+ALTER TABLE `ingredients`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `ingredient_company_idx` (`company_id`);
+
 ALTER TABLE `product_custom_groups`
-  ADD KEY `product_id` (`product_id`);
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `pcg_product_idx` (`product_id`);
 
 ALTER TABLE `product_custom_items`
-  ADD KEY `group_id` (`group_id`);
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `pci_group_idx` (`group_id`),
+  ADD KEY `pci_ingredient_idx` (`ingredient_id`);
 
 ALTER TABLE `users`
   ADD PRIMARY KEY (`id`),
@@ -295,11 +302,10 @@ ALTER TABLE `users`
 -- --------------------------------------------------------
 -- AUTO_INCREMENT
 -- --------------------------------------------------------
-
-ALTER TABLE `categories`
+ALTER TABLE `companies`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
 
-ALTER TABLE `companies`
+ALTER TABLE `categories`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
 
 ALTER TABLE `company_hours`
@@ -314,9 +320,6 @@ ALTER TABLE `orders`
 ALTER TABLE `products`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
 
-ALTER TABLE `ingredients`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
-
 ALTER TABLE `combo_groups`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
@@ -324,6 +327,9 @@ ALTER TABLE `combo_group_items`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 ALTER TABLE `order_items`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+ALTER TABLE `ingredients`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 ALTER TABLE `product_custom_groups`
@@ -336,9 +342,8 @@ ALTER TABLE `users`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
 
 -- --------------------------------------------------------
--- RESTRIÇÕES (FKs)  — criadas por último
+-- Restrições para tabelas despejadas
 -- --------------------------------------------------------
-
 ALTER TABLE `categories`
   ADD CONSTRAINT `categories_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE CASCADE;
 
@@ -355,9 +360,6 @@ ALTER TABLE `products`
   ADD CONSTRAINT `products_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE CASCADE,
   ADD CONSTRAINT `products_ibfk_2` FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`) ON DELETE SET NULL;
 
-ALTER TABLE `ingredients`
-  ADD CONSTRAINT `ingredients_ibfk_1` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE;
-
 ALTER TABLE `combo_groups`
   ADD CONSTRAINT `combo_groups_ibfk_1` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE;
 
@@ -369,11 +371,15 @@ ALTER TABLE `order_items`
   ADD CONSTRAINT `order_items_ibfk_1` FOREIGN KEY (`order_id`) REFERENCES `orders` (`id`) ON DELETE CASCADE,
   ADD CONSTRAINT `order_items_ibfk_2` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE;
 
+ALTER TABLE `ingredients`
+  ADD CONSTRAINT `fk_ingredients_company` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE CASCADE;
+
 ALTER TABLE `product_custom_groups`
   ADD CONSTRAINT `fk_pcg_product` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE;
 
 ALTER TABLE `product_custom_items`
-  ADD CONSTRAINT `fk_pci_group` FOREIGN KEY (`group_id`) REFERENCES `product_custom_groups` (`id`) ON DELETE CASCADE;
+  ADD CONSTRAINT `fk_pci_group` FOREIGN KEY (`group_id`) REFERENCES `product_custom_groups` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_pci_ingredient` FOREIGN KEY (`ingredient_id`) REFERENCES `ingredients` (`id`) ON DELETE SET NULL;
 
 ALTER TABLE `users`
   ADD CONSTRAINT `users_ibfk_1` FOREIGN KEY (`company_id`) REFERENCES `companies` (`id`) ON DELETE SET NULL;
@@ -381,5 +387,5 @@ ALTER TABLE `users`
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
- //*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
- //*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/database/migrations/20230901_create_product_customization_tables.sql
+++ b/database/migrations/20230901_create_product_customization_tables.sql
@@ -1,4 +1,17 @@
--- Tabelas de personalização de produtos
+-- Cadastro de ingredientes e tabelas de personalização de produtos
+
+CREATE TABLE IF NOT EXISTS ingredients (
+  id          INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  company_id  INT(11)      NOT NULL,
+  name        VARCHAR(200) NOT NULL,
+  min_qty     INT          NOT NULL DEFAULT 0,
+  max_qty     INT          NOT NULL DEFAULT 1,
+  image_path  VARCHAR(255) DEFAULT NULL,
+  created_at  DATETIME     DEFAULT CURRENT_TIMESTAMP,
+  updated_at  DATETIME     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_ingredients_company FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS product_custom_groups (
   id         INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   product_id INT(11) NOT NULL,
@@ -11,11 +24,16 @@ CREATE TABLE IF NOT EXISTS product_custom_groups (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS product_custom_items (
-  id         INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  group_id   INT UNSIGNED NOT NULL,
-  label      VARCHAR(200) NOT NULL,
-  delta      DECIMAL(10,2) NOT NULL DEFAULT 0.00,
-  is_default TINYINT(1) NOT NULL DEFAULT 0,
-  sort_order INT NOT NULL DEFAULT 0,
-  CONSTRAINT fk_pci_group FOREIGN KEY (group_id) REFERENCES product_custom_groups(id) ON DELETE CASCADE
+  id            INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  group_id      INT UNSIGNED NOT NULL,
+  ingredient_id INT UNSIGNED DEFAULT NULL,
+  label         VARCHAR(200) NOT NULL,
+  delta         DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+  is_default    TINYINT(1) NOT NULL DEFAULT 0,
+  default_qty   INT NOT NULL DEFAULT 1,
+  min_qty       INT NOT NULL DEFAULT 0,
+  max_qty       INT NOT NULL DEFAULT 1,
+  sort_order    INT NOT NULL DEFAULT 0,
+  CONSTRAINT fk_pci_group      FOREIGN KEY (group_id) REFERENCES product_custom_groups(id) ON DELETE CASCADE,
+  CONSTRAINT fk_pci_ingredient FOREIGN KEY (ingredient_id) REFERENCES ingredients(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,14 @@ $router->get('/admin/{slug}/products/{id}/edit',    'AdminProductController@edit
 $router->post('/admin/{slug}/products/{id}',        'AdminProductController@update');
 $router->post('/admin/{slug}/products/{id}/del',    'AdminProductController@destroy');
 
+// Ingredientes (CRUD)
+$router->get('/admin/{slug}/ingredients',              'AdminIngredientController@index');
+$router->get('/admin/{slug}/ingredients/create',       'AdminIngredientController@create');
+$router->post('/admin/{slug}/ingredients',             'AdminIngredientController@store');
+$router->get('/admin/{slug}/ingredients/{id}/edit',    'AdminIngredientController@edit');
+$router->post('/admin/{slug}/ingredients/{id}',        'AdminIngredientController@update');
+$router->post('/admin/{slug}/ingredients/{id}/del',    'AdminIngredientController@destroy');
+
 /* ========= Constraints globais ========= */
 if (method_exists($router, 'where')) {
   $router->where('slug', '[a-z0-9\-]+');


### PR DESCRIPTION
## Summary
- block ingredient creation and edition with repeated names per company, surfacing a clear flash message
- add a helper on the Ingredient model to detect existing records case-insensitively
- skip duplicate ingredient selections when normalizing product customization groups

## Testing
- php -l app/controllers/AdminIngredientController.php
- php -l app/models/Ingredient.php
- php -l app/models/ProductCustomization.php

------
https://chatgpt.com/codex/tasks/task_e_68cd8e78b4ac832eadc9411f2d263572