### PR TITLE
Refine promotional price validation and display

### DIFF
--- a/app/controllers/PublicHomeController.php
+++ b/app/controllers/PublicHomeController.php
@@ -108,7 +108,31 @@ class PublicHomeController extends Controller
       // Retorna o HTML com os produtos para busca instantânea
       $products = Product::listByCompany($cid, $q);
       if (!function_exists('badgePromo')) {
-        function badgePromo($p){ return !empty($p['promo_price']); }
+        function badgePromo($p){
+          if (!is_array($p)) return false;
+          $price = isset($p['price']) ? (float)$p['price'] : 0;
+          $promoRaw = $p['promo_price'] ?? null;
+          if ($price <= 0 || $promoRaw === null || $promoRaw === '') {
+            return false;
+          }
+          if (is_array($promoRaw)) {
+            $promoRaw = reset($promoRaw);
+          }
+          $promoStr = trim((string)$promoRaw);
+          if ($promoStr === '') {
+            return false;
+          }
+          $promoStr = str_replace(' ', '', $promoStr);
+          if (strpos($promoStr, ',') !== false && strpos($promoStr, '.') !== false) {
+            $promoStr = str_replace('.', '', $promoStr);
+          }
+          $promoStr = str_replace(',', '.', $promoStr);
+          if (!is_numeric($promoStr)) {
+            return false;
+          }
+          $promo = (float)$promoStr;
+          return $promo > 0 && $promo < $price;
+        }
       }
       ob_start();
       if ($q !== '') {

--- a/app/models/Product.php
+++ b/app/models/Product.php
@@ -4,6 +4,43 @@ require_once __DIR__ . '/../config/db.php';
 
 class Product
 {
+  private static function normalizePromoValue($promo, $price): ?float {
+    if ($promo === null || $promo === '') {
+      return null;
+    }
+
+    if (is_array($promo)) {
+      $promo = reset($promo);
+    }
+
+    $promoStr = trim((string)$promo);
+    if ($promoStr === '') {
+      return null;
+    }
+
+    $promoStr = str_replace(' ', '', $promoStr);
+    if (strpos($promoStr, ',') !== false && strpos($promoStr, '.') !== false) {
+      $promoStr = str_replace('.', '', $promoStr);
+    }
+    $promoStr = str_replace(',', '.', $promoStr);
+
+    if (!is_numeric($promoStr) && !is_numeric($promo)) {
+      return null;
+    }
+
+    $promoVal = (float)$promoStr;
+    $priceVal = (float)$price;
+
+    if ($promoVal <= 0) {
+      return null;
+    }
+
+    if ($priceVal <= 0 || $promoVal >= $priceVal) {
+      return null;
+    }
+
+    return $promoVal;
+  }
   /* ========================
    * LISTAGENS / BÁSICO
    * ======================== */
@@ -71,7 +108,7 @@ class Product
       $data['name'],
       $data['description'] ?? null,
       (float)$data['price'],
-      $data['promo_price'] !== '' ? (float)$data['promo_price'] : null,
+      self::normalizePromoValue($data['promo_price'] ?? null, $data['price'] ?? 0),
       $data['sku'] ?? null,
       $data['image'] ?? null,
       $data['type'] ?? 'simple',           // 'simple' | 'combo'
@@ -105,7 +142,7 @@ class Product
       $data['name'],
       $data['description'] ?? null,
       (float)$data['price'],
-      $data['promo_price'] !== '' ? (float)$data['promo_price'] : null,
+      self::normalizePromoValue($data['promo_price'] ?? null, $data['price'] ?? 0),
       $data['sku'] ?? null,
       $data['image'] ?? null,
       $data['type'] ?? 'simple',

--- a/app/views/admin/products/form.php
+++ b/app/views/admin/products/form.php
@@ -1138,11 +1138,22 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
       if(!name.value.trim()){ e.preventDefault(); alert('Informe o nome do produto.'); name.focus(); return; }
 
       // Normaliza BR -> float
-      ['price','promo_price'].forEach(id=>{ const el=document.getElementById(id); if(!el) return; el.value=String(brToFloat(el.value||'0')); });
+      const priceEl = document.getElementById('price');
+      if(priceEl){ priceEl.value = String(brToFloat(priceEl.value||'0')); }
 
-      const price=parseFloat(document.getElementById('price').value||'0');
-      const promo=parseFloat(document.getElementById('promo_price').value||'0');
-      if(promo && price && promo>=price){ e.preventDefault(); alert('O preço promocional deve ser menor que o preço base.'); document.getElementById('promo_price').focus(); return; }
+      const promoEl = document.getElementById('promo_price');
+      if(promoEl){
+        const rawPromo = promoEl.value == null ? '' : String(promoEl.value).trim();
+        promoEl.value = rawPromo === '' ? '' : String(brToFloat(rawPromo));
+      }
+
+      const price=parseFloat((priceEl?.value||'0'));
+      const promoRaw = promoEl?.value ?? '';
+      const promo = promoRaw === '' ? null : parseFloat(promoRaw || '0');
+      if(promo !== null && !Number.isNaN(promo)){
+        if(promo <= 0 || price <= 0){ promoEl.value = ''; }
+        else if(promo >= price){ e.preventDefault(); alert('O preço promocional deve ser menor que o preço base.'); document.getElementById('promo_price').focus(); return; }
+      }
 
       // COMBO
       if(groupsToggle && groupsToggle.checked){

--- a/app/views/public/home.php
+++ b/app/views/public/home.php
@@ -8,7 +8,31 @@ if (!function_exists('e')) {
 }
 
 /* Helpers de badges */
-function badgePromo($p){ return !empty($p['promo_price']); }
+function badgePromo($p){
+  if (!is_array($p)) return false;
+  $price = isset($p['price']) ? (float)$p['price'] : 0;
+  $promoRaw = $p['promo_price'] ?? null;
+  if ($price <= 0 || $promoRaw === null || $promoRaw === '') {
+    return false;
+  }
+  if (is_array($promoRaw)) {
+    $promoRaw = reset($promoRaw);
+  }
+  $promoStr = trim((string)$promoRaw);
+  if ($promoStr === '') {
+    return false;
+  }
+  $promoStr = str_replace(' ', '', $promoStr);
+  if (strpos($promoStr, ',') !== false && strpos($promoStr, '.') !== false) {
+    $promoStr = str_replace('.', '', $promoStr);
+  }
+  $promoStr = str_replace(',', '.', $promoStr);
+  if (!is_numeric($promoStr)) {
+    return false;
+  }
+  $promo = (float)$promoStr;
+  return $promo > 0 && $promo < $price;
+}
 // usa o helper global do seu projeto para novidade
 if (!function_exists('badgeNew')) {
   function badgeNew($p){ return is_new_product($p); }

--- a/app/views/public/partials_card.php
+++ b/app/views/public/partials_card.php
@@ -22,17 +22,37 @@
         </p>
       <?php endif; ?>
 
+      <?php
+        $priceVal = isset($p['price']) ? (float)$p['price'] : 0;
+        $promoRaw = $p['promo_price'] ?? null;
+        $promoVal = null;
+        if ($promoRaw !== null && $promoRaw !== '') {
+          $promoStr = is_array($promoRaw) ? reset($promoRaw) : $promoRaw;
+          $promoStr = trim((string)$promoStr);
+          if ($promoStr !== '') {
+            $promoStr = str_replace(' ', '', $promoStr);
+            if (strpos($promoStr, ',') !== false && strpos($promoStr, '.') !== false) {
+              $promoStr = str_replace('.', '', $promoStr);
+            }
+            $promoStr = str_replace(',', '.', $promoStr);
+            if (is_numeric($promoStr)) {
+              $promoVal = (float)$promoStr;
+            }
+          }
+        }
+        $hasPromo = $priceVal > 0 && $promoVal !== null && $promoVal > 0 && $promoVal < $priceVal;
+      ?>
       <div class="mt-1">
-        <?php if (!empty($p['promo_price'])): ?>
+        <?php if ($hasPromo): ?>
           <span class="text-sm text-gray-400 line-through">
-            R$ <?= number_format($p['price'], 2, ',', '.') ?>
+            R$ <?= number_format($priceVal, 2, ',', '.') ?>
           </span>
           <span class="ml-2 text-lg font-bold">
-            R$ <?= number_format($p['promo_price'], 2, ',', '.') ?>
+            R$ <?= number_format($promoVal, 2, ',', '.') ?>
           </span>
         <?php else: ?>
           <span class="text-lg font-bold">
-            R$ <?= number_format($p['price'], 2, ',', '.') ?>
+            R$ <?= number_format($priceVal, 2, ',', '.') ?>
           </span>
         <?php endif; ?>
       </div>

--- a/app/views/public/product.php
+++ b/app/views/public/product.php
@@ -54,7 +54,12 @@ $addToCartUrl  = base_url($slug . '/orders/add');                               
   .brand .dot{width:18px;height:18px;border-radius:999px;background:#ffb703;display:grid;place-items:center;color:#7c2d12;font-weight:800;font-size:11px}
   h1{margin:2px 0 0;font-size:20px;line-height:1.25;font-weight:700}
   .price-row{display:flex;align-items:center;justify-content:space-between;margin-top:4px}
-  .price{font-size:22px;font-weight:800}
+  .price{display:flex;flex-direction:column;gap:4px}
+  .price-single{font-size:22px;font-weight:800}
+  .price-original{font-size:15px;font-weight:600;color:#9ca3af;text-decoration:line-through}
+  .price-current-row{display:flex;align-items:baseline;gap:10px}
+  .price-current{font-size:24px;font-weight:800}
+  .price-discount{font-size:16px;font-weight:700;color:#059669}
 
   .qty{display:flex;align-items:center;gap:8px}
   .btn-circ{width:40px;height:40px;border-radius:12px;border:1px solid var(--border);background:var(--card);display:grid;place-items:center;cursor:pointer}
@@ -124,9 +129,36 @@ $addToCartUrl  = base_url($slug . '/orders/add');                               
       <div class="price">
         <?php
           $price = (float)($product['price'] ?? 0);
-          $promo = (float)($product['promo_price'] ?? 0);
-          echo ($promo && $promo < $price) ? price_br($promo) : price_br($price);
+          $rawPromo = $product['promo_price'] ?? null;
+          $promo = null;
+          if ($rawPromo !== null && $rawPromo !== '') {
+            $promoStr = is_array($rawPromo) ? reset($rawPromo) : $rawPromo;
+            $promoStr = trim((string)$promoStr);
+            if ($promoStr !== '') {
+              $promoStr = str_replace(' ', '', $promoStr);
+              if (strpos($promoStr, ',') !== false && strpos($promoStr, '.') !== false) {
+                $promoStr = str_replace('.', '', $promoStr);
+              }
+              $promoStr = str_replace(',', '.', $promoStr);
+              if (is_numeric($promoStr)) {
+                $promo = (float)$promoStr;
+              }
+            }
+          }
+          $hasPromo = $price > 0 && $promo !== null && $promo > 0 && $promo < $price;
+          if ($hasPromo):
+            $discount = $price > 0 ? (int)floor((($price - $promo) / $price) * 100) : 0;
         ?>
+          <div class="price-original"><?= price_br($price) ?></div>
+          <div class="price-current-row">
+            <span class="price-current"><?= price_br($promo) ?></span>
+            <?php if ($discount > 0): ?>
+              <span class="price-discount"><?= $discount ?>% OFF</span>
+            <?php endif; ?>
+          </div>
+        <?php else: ?>
+          <div class="price-single"><?= price_br($price) ?></div>
+        <?php endif; ?>
       </div>
 
       <div class="qty" aria-label="Selecionar quantidade">


### PR DESCRIPTION
## Summary
- keep promotional price empty during product save normalization to avoid forcing zero values
- render promotional price on the public product page with original price strike-through and discount badge when applicable
- normalize promotional price inputs to discard zero/invalid values and hide promo visuals when the discount is not valid

## Testing
- php -l app/controllers/AdminProductController.php
- php -l app/controllers/PublicHomeController.php
- php -l app/models/Product.php
- php -l app/views/admin/products/form.php
- php -l app/views/public/home.php
- php -l app/views/public/partials_card.php
- php -l app/views/public/product.php

------
https://chatgpt.com/codex/tasks/task_e_68ce42e84388832e9365583d6307f826