### PR TITLE
Atualiza card de pedidos no dashboard

### DIFF
--- a/app/controllers/AdminDashboardController.php
+++ b/app/controllers/AdminDashboardController.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../models/Company.php';
 require_once __DIR__ . '/../models/Category.php';
 require_once __DIR__ . '/../models/Product.php';
 require_once __DIR__ . '/../models/Ingredient.php';
+require_once __DIR__ . '/../models/Order.php';
 
 class AdminDashboardController extends Controller
 {
@@ -62,6 +63,7 @@ class AdminDashboardController extends Controller
     $categories = Category::listByCompany($companyId);
     $products   = Product::listByCompany($companyId);
     $ingredientsCount = Ingredient::countByCompany($companyId);
+    $ordersCount = Order::countByCompany($companyId);
     $recentIngredients = Ingredient::listRecentByCompany($companyId, 8);
     foreach ($recentIngredients as &$ing) {
       $assigned = Ingredient::assignedProducts((int)$ing['id']);
@@ -78,6 +80,7 @@ class AdminDashboardController extends Controller
       'categories',
       'products',
       'ingredientsCount',
+      'ordersCount',
       'recentIngredients',
       'activeSlug'
     ));

--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once __DIR__ . '/../config/db.php';
+
 class Order
 {
   public static function listByCompany(PDO $db, int $companyId, ?string $status=null, int $limit=50, int $offset=0): array {
@@ -63,5 +66,14 @@ class Order
     if (!in_array($status, $allowed, true)) return false;
     $st = $db->prepare("UPDATE orders SET status=? WHERE id=? AND company_id=?");
     return $st->execute([$status, $orderId, $companyId]);
+  }
+
+  public static function countByCompany(int $companyId): int
+  {
+    $pdo = db();
+    $st = $pdo->prepare('SELECT COUNT(*) AS total FROM orders WHERE company_id = ?');
+    $st->execute([$companyId]);
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    return (int)($row['total'] ?? 0);
   }
 }

--- a/app/views/admin/dashboard/index.php
+++ b/app/views/admin/dashboard/index.php
@@ -14,6 +14,7 @@ $categories         = is_array($categories ?? null) ? $categories : [];
 $products           = is_array($products ?? null) ? $products : [];
 $recentIngredients  = is_array($recentIngredients ?? null) ? $recentIngredients : [];
 $ingredientsCount   = (int)($ingredientsCount ?? 0);
+$ordersCount        = (int)($ordersCount ?? 0);
 
 // Slugs/título com fallback
 $activeSlug = (string)($activeSlug ?? ($company['slug'] ?? ''));
@@ -109,12 +110,11 @@ ob_start(); ?>
 
   <div class="rounded-2xl bg-white border p-4">
     <div class="text-sm text-gray-500 mb-1">Pedidos</div>
-    <div class="text-3xl font-bold mb-3">
-      <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="currentColor" class="inline-block w-12 h-12" viewBox="0 0 16 16" aria-hidden="true">
-        <path d="M8.186 1.113a.5.5 0 0 0-.372 0L1.846 3.5l2.404.961L10.404 2zm3.564 1.426L5.596 5 8 5.961 14.154 3.5zm3.25 1.7-6.5 2.6v7.922l6.5-2.6V4.24zM7.5 14.762V6.838L1 4.239v7.923zM7.443.184a1.5 1.5 0 0 1 1.114 0l7.129 2.852A.5.5 0 0 1 16 3.5v8.662a1 1 0 0 1-.629.928l-7.185 2.874a.5.5 0 0 1-.372 0L.63 13.09a1 1 0 0 1-.63-.928V3.5a.5.5 0 0 1 .314-.464z" />
-      </svg>
+    <div class="text-3xl font-bold mb-3"><?= (int)$ordersCount ?></div>
+    <div class="flex gap-2">
+      <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/orders')) ?>">Ver pedidos</a>
+      <a class="px-3 py-2 rounded-xl border" href="<?= e(base_url('admin/' . $slug . '/orders/create')) ?>">+ Novo</a>
     </div>
-    <a class="px-3 py-2 rounded-xl border inline-block" href="<?= e(base_url('admin/' . $slug . '/orders')) ?>">Ver pedidos</a>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- exibe o total de pedidos cadastrados no card da dashboard e adiciona o atalho de criação
- inclui cálculo da contagem de pedidos no controller e modelo para reutilização

## Testing
- php -l app/models/Order.php
- php -l app/views/admin/dashboard/index.php

------
https://chatgpt.com/codex/tasks/task_e_68cf59dc1ac4832eba1e9b0c196695db