### PR TITLE
Bloqueia zoom nas páginas públicas

### DIFF
--- a/app/views/public/customization.php
+++ b/app/views/public/customization.php
@@ -50,7 +50,7 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
 <html lang="pt-br">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <title>Personalizar — <?= e($pName) ?> | <?= e($company['name'] ?? '') ?></title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/app/views/public/layout.php
+++ b/app/views/public/layout.php
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title><?= e($title ?? 'Cardápio') ?></title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-50 text-gray-900">

--- a/app/views/public/product.php
+++ b/app/views/public/product.php
@@ -28,7 +28,7 @@ $addToCartUrl  = base_url($slug . '/orders/add');                               
 <html lang="pt-br">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <title><?= e($product['name'] ?? 'Produto') ?> — <?= e($company['name'] ?? '') ?></title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- impede zoom nos layouts públicos ajustando a meta viewport
- aplica o mesmo bloqueio às páginas específicas de produto e personalização

## Testing
- php -l app/views/public/layout.php
- php -l app/views/public/product.php
- php -l app/views/public/customization.php

------
https://chatgpt.com/codex/tasks/task_e_68cf85a42c7c832ebe76faa8ba28f12a