### PR TITLE
Add customizable menu colors in admin settings

### DIFF
--- a/app/controllers/AdminSettingsController.php
+++ b/app/controllers/AdminSettingsController.php
@@ -116,6 +116,26 @@ class AdminSettingsController extends Controller {
     return null;
   }
 
+  private function normalizeColor(?string $value, ?string $fallback = null): ?string {
+    $value = trim((string)($value ?? ''));
+    if ($value === '') {
+      return null;
+    }
+    if ($value[0] !== '#') {
+      $value = '#' . $value;
+    }
+    if (!preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $value)) {
+      if ($fallback === null) {
+        return null;
+      }
+      return $this->normalizeColor($fallback, null);
+    }
+    if (strlen($value) === 4) {
+      $value = '#' . $value[1] . $value[1] . $value[2] . $value[2] . $value[3] . $value[3];
+    }
+    return strtoupper($value);
+  }
+
   public function save($params){
     [$u,$company] = $this->guard($params['slug']);
 
@@ -125,6 +145,13 @@ class AdminSettingsController extends Controller {
     $address   = trim($_POST['address'] ?? $company['address']);
     $highlight = trim($_POST['highlight_text'] ?? $company['highlight_text']);
     $min_order = ($_POST['min_order'] === '' ? null : (float)$_POST['min_order']);
+
+    $headerColor      = $this->normalizeColor($_POST['menu_header_text_color']     ?? null, $company['menu_header_text_color']     ?? null);
+    $logoBgColor      = $this->normalizeColor($_POST['menu_logo_bg_color']         ?? null, $company['menu_logo_bg_color']         ?? null);
+    $groupBgColor     = $this->normalizeColor($_POST['menu_group_title_bg_color']  ?? null, $company['menu_group_title_bg_color']  ?? null);
+    $groupTextColor   = $this->normalizeColor($_POST['menu_group_title_text_color']?? null, $company['menu_group_title_text_color']?? null);
+    $welcomeBgColor   = $this->normalizeColor($_POST['menu_welcome_bg_color']      ?? null, $company['menu_welcome_bg_color']      ?? null);
+    $welcomeTextColor = $this->normalizeColor($_POST['menu_welcome_text_color']    ?? null, $company['menu_welcome_text_color']    ?? null);
 
     // Tempo médio (inteiros ou NULL)
     $avg_from = (isset($_POST['avg_delivery_min_from']) && $_POST['avg_delivery_min_from'] !== '')
@@ -142,8 +169,8 @@ class AdminSettingsController extends Controller {
     if ($errMsgs)     $_SESSION['flash_error'] = implode(' ', $errMsgs);
 
     // ----- UPDATE companies
-    $set  = "name=?, whatsapp=?, address=?, highlight_text=?, min_order=?, avg_delivery_min_from=?, avg_delivery_min_to=?";
-    $vals = [$name, $whatsapp, $address, $highlight, $min_order, $avg_from, $avg_to];
+    $set  = "name=?, whatsapp=?, address=?, highlight_text=?, min_order=?, avg_delivery_min_from=?, avg_delivery_min_to=?, menu_header_text_color=?, menu_logo_bg_color=?, menu_group_title_bg_color=?, menu_group_title_text_color=?, menu_welcome_bg_color=?, menu_welcome_text_color=?";
+    $vals = [$name, $whatsapp, $address, $highlight, $min_order, $avg_from, $avg_to, $headerColor, $logoBgColor, $groupBgColor, $groupTextColor, $welcomeBgColor, $welcomeTextColor];
 
     if ($newLogoPath)   { $set .= ", logo=?";   $vals[] = $newLogoPath; }
     if ($newBannerPath) { $set .= ", banner=?"; $vals[] = $newBannerPath; }

--- a/app/views/admin/settings/index.php
+++ b/app/views/admin/settings/index.php
@@ -2,6 +2,39 @@
 $title = "Configurações - " . ($company['name'] ?? '');
 $days = [1=>'Segunda',2=>'Terça',3=>'Quarta',4=>'Quinta',5=>'Sexta',6=>'Sábado',7=>'Domingo'];
 $slug = rawurlencode($company['slug']);
+
+if (!function_exists('settings_color_value')) {
+  function settings_color_value($value, $default) {
+    $value = trim((string)$value);
+    if ($value === '') {
+      return strtoupper($default);
+    }
+    if ($value[0] !== '#') {
+      $value = '#' . $value;
+    }
+    if (!preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $value)) {
+      return strtoupper($default);
+    }
+    if (strlen($value) === 4) {
+      $value = '#' . $value[1] . $value[1] . $value[2] . $value[2] . $value[3] . $value[3];
+    }
+    return strtoupper($value);
+  }
+}
+
+$colorDefaults = [
+  'menu_header_text_color'      => '#FFFFFF',
+  'menu_logo_bg_color'          => '#FFFFFF',
+  'menu_group_title_bg_color'   => '#FACC15',
+  'menu_group_title_text_color' => '#000000',
+  'menu_welcome_bg_color'       => '#6B21A8',
+  'menu_welcome_text_color'     => '#FFFFFF',
+];
+
+$colorValues = [];
+foreach ($colorDefaults as $key => $default) {
+  $colorValues[$key] = settings_color_value($company[$key] ?? '', $default);
+}
 ob_start(); ?>
 <h1 class="text-2xl font-bold mb-4">Configurações gerais</h1>
 
@@ -54,6 +87,43 @@ ob_start(); ?>
     <span class="text-sm">Texto de destaque (boas-vindas)</span>
     <textarea name="highlight_text" rows="3" class="border rounded-xl p-2"><?= e($company['highlight_text']) ?></textarea>
   </label>
+
+  <hr class="my-2">
+
+  <h2 class="text-lg font-semibold">Aparência do cardápio</h2>
+  <p class="text-sm text-gray-600">Personalize as cores exibidas no cardápio on-line.</p>
+
+  <div class="grid md:grid-cols-2 gap-3">
+    <label class="grid gap-1">
+      <span class="text-sm">Cor dos textos e botões no cabeçalho do cardápio</span>
+      <input type="color" name="menu_header_text_color" value="<?= e($colorValues['menu_header_text_color']) ?>" class="border rounded-xl h-12">
+    </label>
+
+    <label class="grid gap-1">
+      <span class="text-sm">Cor de fundo ao redor do logo</span>
+      <input type="color" name="menu_logo_bg_color" value="<?= e($colorValues['menu_logo_bg_color']) ?>" class="border rounded-xl h-12">
+    </label>
+
+    <label class="grid gap-1">
+      <span class="text-sm">Cor de fundo do título dos grupos do cardápio</span>
+      <input type="color" name="menu_group_title_bg_color" value="<?= e($colorValues['menu_group_title_bg_color']) ?>" class="border rounded-xl h-12">
+    </label>
+
+    <label class="grid gap-1">
+      <span class="text-sm">Cor do título dos grupos do cardápio</span>
+      <input type="color" name="menu_group_title_text_color" value="<?= e($colorValues['menu_group_title_text_color']) ?>" class="border rounded-xl h-12">
+    </label>
+
+    <label class="grid gap-1">
+      <span class="text-sm">Cor de fundo da mensagem de boas-vindas</span>
+      <input type="color" name="menu_welcome_bg_color" value="<?= e($colorValues['menu_welcome_bg_color']) ?>" class="border rounded-xl h-12">
+    </label>
+
+    <label class="grid gap-1">
+      <span class="text-sm">Cor do texto da mensagem de boas-vindas</span>
+      <input type="color" name="menu_welcome_text_color" value="<?= e($colorValues['menu_welcome_text_color']) ?>" class="border rounded-xl h-12">
+    </label>
+  </div>
 
   <div class="grid md:grid-cols-2 gap-4">
     <div>

--- a/app/views/public/home.php
+++ b/app/views/public/home.php
@@ -38,6 +38,32 @@ if (!function_exists('badgeNew')) {
   function badgeNew($p){ return is_new_product($p); }
 }
 
+if (!function_exists('normalize_color_hex')) {
+  function normalize_color_hex($value, $default) {
+    $value = trim((string)$value);
+    if ($value === '') {
+      return strtoupper($default);
+    }
+    if ($value[0] !== '#') {
+      $value = '#' . $value;
+    }
+    if (!preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $value)) {
+      return strtoupper($default);
+    }
+    if (strlen($value) === 4) {
+      $value = '#' . $value[1] . $value[1] . $value[2] . $value[2] . $value[3] . $value[3];
+    }
+    return strtoupper($value);
+  }
+}
+
+$headerColor    = normalize_color_hex($company['menu_header_text_color']      ?? '', '#FFFFFF');
+$logoBgColor    = normalize_color_hex($company['menu_logo_bg_color']          ?? '', '#FFFFFF');
+$groupBgColor   = normalize_color_hex($company['menu_group_title_bg_color']   ?? '', '#FACC15');
+$groupTextColor = normalize_color_hex($company['menu_group_title_text_color'] ?? '', '#000000');
+$welcomeBgColor = normalize_color_hex($company['menu_welcome_bg_color']       ?? '', '#6B21A8');
+$welcomeText    = normalize_color_hex($company['menu_welcome_text_color']     ?? '', '#FFFFFF');
+
 /* Variáveis vindas do controller (com fallbacks para evitar notices) */
 $q              = $q              ?? '';
 $novidades      = $novidades      ?? [];
@@ -67,6 +93,36 @@ $showFooterMenu = true;
     .no-focus-ring:focus-within,
     .no-focus-ring:target { outline: none !important; box-shadow: none !important; }
     .no-focus-ring { -webkit-tap-highlight-color: transparent; }
+    .menu-header {
+      color: <?= e($headerColor) ?>;
+      --menu-header-color: <?= e($headerColor) ?>;
+    }
+    .menu-header .status-badge,
+    .menu-header .menu-header-btn,
+    .menu-header .menu-header-icon {
+      background-color: var(--menu-header-color);
+      color: #ffffff;
+    }
+    .menu-header .status-badge.closed {
+      opacity: 0.65;
+    }
+    .menu-header .menu-header-btn-outline {
+      border: 1px solid var(--menu-header-color);
+      color: var(--menu-header-color);
+      background-color: transparent;
+      transition: background-color .2s ease, color .2s ease;
+    }
+    .menu-header .menu-header-btn-outline:hover,
+    .menu-header .menu-header-btn-outline:focus-visible {
+      background-color: var(--menu-header-color);
+      color: #ffffff;
+    }
+    .menu-header .menu-header-link {
+      color: var(--menu-header-color);
+    }
+    .menu-header .menu-header-link:hover {
+      opacity: .9;
+    }
   </style>
   <div class="rounded-2xl overflow-hidden">
     <?php if ($bannerUrl): ?>
@@ -78,22 +134,24 @@ $showFooterMenu = true;
       <div class="bg-purple-900 h-24"></div>
     <?php endif; ?>
 
-    <div class="bg-purple-900 text-white p-5 relative -mt-10 rounded-t-2xl no-focus-ring">
+    <div class="bg-purple-900 p-5 relative -mt-10 rounded-t-2xl no-focus-ring menu-header">
       <img src="<?= base_url($company['logo'] ?? 'assets/logo-placeholder.png') ?>"
-           class="w-24 h-24 rounded-full object-cover border-4 border-purple-700 bg-white absolute -top-10 right-6 pointer-events-none"
+           class="w-24 h-24 rounded-full object-cover border-4 border-purple-700 absolute -top-10 right-6 pointer-events-none"
+           style="background-color: <?= e($logoBgColor) ?>;"
            alt="<?= e($company['name'] ?? 'Logo') ?>">
       <div class="min-w-0 pr-28">
         <h1 class="text-2xl font-bold"><?= e($company['name'] ?? 'Empresa') ?></h1>
 
         <!-- Linha de status + horário de hoje + info -->
         <div class="flex flex-wrap items-center gap-2 text-sm mt-1">
-            <span class="<?= !empty($isOpenNow) ? 'bg-yellow-400 text-black' : 'bg-gray-300 text-gray-800' ?> px-2 py-0.5 rounded-lg font-semibold">
+            <?php $statusClass = !empty($isOpenNow) ? 'open' : 'closed'; ?>
+            <span class="status-badge inline-flex items-center px-2 py-0.5 rounded-lg font-semibold <?= $statusClass ?>">
               <?= !empty($isOpenNow) ? 'Aberto!' : 'Fechado' ?>
             </span>
 
             <?php if (!empty($todayLabel)): ?>
-              <button type="button" id="btn-hours" class="font-semibold"><?= e($todayLabel) ?></button>
-              <span id="btn-hours-ico" class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-yellow-400 text-black cursor-pointer" aria-hidden="true">i</span>
+              <button type="button" id="btn-hours" class="font-semibold menu-header-link"><?= e($todayLabel) ?></button>
+              <span id="btn-hours-ico" class="menu-header-icon inline-flex items-center justify-center w-5 h-5 rounded-full cursor-pointer" aria-hidden="true">i</span>
             <?php endif; ?>
 
             <?php if (!empty($company['min_order'])): ?>
@@ -103,7 +161,7 @@ $showFooterMenu = true;
             <?php endif; ?>
 
             <?php if (!empty($company['whatsapp'])): ?>
-              <a class="inline-flex items-center gap-1 underline" href="https://wa.me/<?= e(preg_replace('/\D+/', '', (string)$company['whatsapp'])) ?>" target="_blank" aria-label="WhatsApp">
+              <a class="inline-flex items-center gap-1 underline menu-header-link" href="https://wa.me/<?= e(preg_replace('/\D+/', '', (string)$company['whatsapp'])) ?>" target="_blank" aria-label="WhatsApp">
                 <!-- ícone WhatsApp (SVG) -->
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#FACC14" class="bi bi-whatsapp" viewBox="0 0 16 16" aria-hidden="true">
                   <path d="M13.601 2.326A7.85 7.85 0 0 0 7.994 0C3.627 0 .068 3.558.064 7.926c0 1.399.366 2.76 1.057 3.965L0 16l4.204-1.102a7.9 7.9 0 0 0 3.79.965h.004c4.368 0 7.926-3.558 7.93-7.93A7.9 7.9 0 0 0 13.6 2.326zM7.994 14.521a6.6 6.6 0 0 1-3.356-.92l-.24-.144-2.494.654.666-2.433-.156-.251a6.56 6.56 0 0 1-1.007-3.505c0-3.626 2.957-6.584 6.591-6.584a6.56 6.56 0 0 1 4.66 1.931 6.56 6.56 0 0 1 1.928 4.66c-.004 3.639-2.961 6.592-6.592 6.592m3.615-4.934c-.197-.099-1.17-.578-1.353-.646-.182-.065-.315-.099-.445.099-.133.197-.513.646-.627.775-.114.133-.232.148-.43.05-.197-.1-.836-.308-1.592-.985-.59-.525-.985-1.175-1.103-1.372-.114-.198-.011-.304.088-.403.087-.088.197-.232.296-.346.1-.114.133-.198.198-.33.065-.134.034-.248-.015-.347-.05-.099-.445-1.076-.612-1.47-.16-.389-.323-.335-.445-.34-.114-.007-.247-.007-.38-.007a.73.73 0 0 0-.529.247c-.182.198-.691.677-.691 1.654s.71 1.916.81 2.049c.098.133 1.394 2.132 3.383 2.992.47.205.84.326 1.129.418.475.152.904.129 1.246.08.38-.058 1.171-.48 1.338-.943.164-.464.164-.86.114-.943-.049-.084-.182-.133-.38-.232"/>
@@ -115,12 +173,12 @@ $showFooterMenu = true;
             <!-- Login ou saudação do cliente -->
             <?php if (!empty($customer) && isset($company['id']) && isset($customer['company_id']) && (int)$customer['company_id'] === (int)$company['id']): ?>
               <div class="flex items-center gap-2 w-full sm:w-auto mt-2 sm:mt-0 self-center">
-                <span class="px-2 py-0.5 rounded-lg bg-white text-purple-900 font-semibold">
+                <span class="px-2 py-0.5 rounded-lg menu-header-btn font-semibold">
                   Olá, <?= e($customer['name'] ?? 'Cliente') ?>
                 </span>
                 <form method="post" action="<?= base_url(rawurlencode((string)$company['slug']).'/customer-logout') ?>" onsubmit="return confirm('Sair?')">
                   <?php if (function_exists('csrf_field')) { echo csrf_field(); } ?>
-                  <button class="px-2 py-0.5 rounded-lg border bg-white text-purple-900 font-semibold hover:bg-slate-50">Sair</button>
+                  <button class="px-2 py-0.5 rounded-lg menu-header-btn-outline font-semibold">Sair</button>
                 </form>
               </div>
             <?php else: ?>
@@ -128,7 +186,7 @@ $showFooterMenu = true;
                 <button
                   type="button"
                   id="btn-open-login"
-                  class="px-2 py-0.5 rounded-lg border bg-white text-purple-900 hover:bg-slate-50 font-semibold">
+                  class="px-2 py-0.5 rounded-lg menu-header-btn-outline font-semibold">
                   Entrar
                 </button>
               </div>
@@ -143,8 +201,8 @@ $showFooterMenu = true;
     </div>
 
     <?php if (!empty($company['highlight_text'])): ?>
-      <div class="bg-purple-100 p-4">
-        <p class="bg-purple-700 text-white p-3 rounded-xl text-sm">
+      <div class="p-4 rounded-xl" style="background-color: <?= e($welcomeBgColor) ?>20;">
+        <p class="p-3 rounded-xl text-sm" style="background-color: <?= e($welcomeBgColor) ?>; color: <?= e($welcomeText) ?>;">
           <?= nl2br(e($company['highlight_text'])) ?>
         </p>
       </div>
@@ -344,7 +402,7 @@ $showFooterMenu = true;
 <!-- ======== BLOCOS NO TOPO ======== -->
 <?php if ($mostraNovidade): ?>
   <a id="novidades"></a>
-  <h2 class="text-xl font-bold bg-yellow-400 text-black inline-block px-3 py-1 rounded-lg mb-2">Novidades</h2>
+  <h2 class="text-xl font-bold inline-block px-3 py-1 rounded-lg mb-2" style="background-color: <?= e($groupBgColor) ?>; color: <?= e($groupTextColor) ?>;">Novidades</h2>
   <div class="grid gap-3 mb-6">
     <?php foreach ($novidades as $p): ?>
       <?php include __DIR__ . '/partials_card.php'; ?>
@@ -358,7 +416,9 @@ $showFooterMenu = true;
 
 <?php foreach ($categories as $c): ?>
   <a id="cat-<?= (int)$c['id'] ?>"></a>
-  <h2 class="text-xl font-bold bg-yellow-400 inline-block px-3 py-1 rounded-lg mb-2"><?= e($c['name'] ?? 'Categoria') ?></h2>
+  <h2 class="text-xl font-bold inline-block px-3 py-1 rounded-lg mb-2" style="background-color: <?= e($groupBgColor) ?>; color: <?= e($groupTextColor) ?>;">
+    <?= e($c['name'] ?? 'Categoria') ?>
+  </h2>
   <?php $items = array_values(array_filter($products, fn($p)=> (int)($p['category_id'] ?? 0) === (int)$c['id'])); ?>
   <div class="grid gap-3 mb-6">
     <?php foreach ($items as $p): include __DIR__ . '/partials_card.php'; endforeach; ?>

--- a/database/menu_schema_with_customization.sql
+++ b/database/menu_schema_with_customization.sql
@@ -38,12 +38,18 @@ CREATE TABLE `companies` (
   `avg_delivery_min_to` int(11) DEFAULT NULL,
   `logo` varchar(255) DEFAULT NULL,
   `banner` varchar(255) DEFAULT NULL,
+  `menu_header_text_color` varchar(20) DEFAULT NULL,
+  `menu_logo_bg_color` varchar(20) DEFAULT NULL,
+  `menu_group_title_bg_color` varchar(20) DEFAULT NULL,
+  `menu_group_title_text_color` varchar(20) DEFAULT NULL,
+  `menu_welcome_bg_color` varchar(20) DEFAULT NULL,
+  `menu_welcome_text_color` varchar(20) DEFAULT NULL,
   `active` tinyint(1) NOT NULL DEFAULT 1,
   `created_at` datetime DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
-INSERT INTO `companies` (`id`, `slug`, `name`, `whatsapp`, `address`, `highlight_text`, `min_order`, `avg_delivery_min_from`, `avg_delivery_min_to`, `logo`, `banner`, `active`, `created_at`) VALUES
-(1, 'wollburger', 'Wollburger', '55', '', '', NULL, NULL, NULL, NULL, NULL, 1, '2025-09-11 01:38:16');
+INSERT INTO `companies` (`id`, `slug`, `name`, `whatsapp`, `address`, `highlight_text`, `min_order`, `avg_delivery_min_from`, `avg_delivery_min_to`, `logo`, `banner`, `menu_header_text_color`, `menu_logo_bg_color`, `menu_group_title_bg_color`, `menu_group_title_text_color`, `menu_welcome_bg_color`, `menu_welcome_text_color`, `active`, `created_at`) VALUES
+(1, 'wollburger', 'Wollburger', '55', '', '', NULL, NULL, NULL, NULL, NULL, '#FFFFFF', '#FFFFFF', '#FACC15', '#000000', '#6B21A8', '#FFFFFF', 1, '2025-09-11 01:38:16');
 
 -- --------------------------------------------------------
 -- Estrutura da tabela `categories`

--- a/database/migrations/20230920_add_menu_color_settings.sql
+++ b/database/migrations/20230920_add_menu_color_settings.sql
@@ -1,0 +1,7 @@
+ALTER TABLE companies
+  ADD COLUMN menu_header_text_color varchar(20) DEFAULT NULL AFTER banner,
+  ADD COLUMN menu_logo_bg_color varchar(20) DEFAULT NULL AFTER menu_header_text_color,
+  ADD COLUMN menu_group_title_bg_color varchar(20) DEFAULT NULL AFTER menu_logo_bg_color,
+  ADD COLUMN menu_group_title_text_color varchar(20) DEFAULT NULL AFTER menu_group_title_bg_color,
+  ADD COLUMN menu_welcome_bg_color varchar(20) DEFAULT NULL AFTER menu_group_title_text_color,
+  ADD COLUMN menu_welcome_text_color varchar(20) DEFAULT NULL AFTER menu_welcome_bg_color;


### PR DESCRIPTION
## Summary
- add six menu color fields to the company schema and expose them on the admin settings page
- persist color selections with validation in the settings controller
- apply the selected colors across the public menu header, welcome message, and group titles

## Testing
- php -l app/controllers/AdminSettingsController.php
- php -l app/views/admin/settings/index.php
- php -l app/views/public/home.php

------
https://chatgpt.com/codex/tasks/task_e_68cfa8459684832ebe62568c39b5e9b0