### PR TITLE
Add configurable colors for menu header and welcome message

### DIFF
--- a/app/controllers/AdminSettingsController.php
+++ b/app/controllers/AdminSettingsController.php
@@ -116,6 +116,17 @@ class AdminSettingsController extends Controller {
     return null;
   }
 
+  private function normalizeColor($value, ?string $current = null): ?string {
+    $value = trim((string)$value);
+    if ($value === '') {
+      return null;
+    }
+    if (preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $value)) {
+      return strtolower($value);
+    }
+    return $current ? strtolower((string)$current) : null;
+  }
+
   public function save($params){
     [$u,$company] = $this->guard($params['slug']);
 
@@ -125,6 +136,13 @@ class AdminSettingsController extends Controller {
     $address   = trim($_POST['address'] ?? $company['address']);
     $highlight = trim($_POST['highlight_text'] ?? $company['highlight_text']);
     $min_order = ($_POST['min_order'] === '' ? null : (float)$_POST['min_order']);
+
+    $headerTextColor      = $this->normalizeColor($_POST['header_text_color']      ?? '', $company['header_text_color']      ?? null);
+    $logoBgColor          = $this->normalizeColor($_POST['header_logo_bg_color']  ?? '', $company['header_logo_bg_color']  ?? null);
+    $groupTitleBgColor    = $this->normalizeColor($_POST['group_title_bg_color']  ?? '', $company['group_title_bg_color']  ?? null);
+    $groupTitleTextColor  = $this->normalizeColor($_POST['group_title_text_color']?? '', $company['group_title_text_color']?? null);
+    $welcomeBgColor       = $this->normalizeColor($_POST['welcome_bg_color']      ?? '', $company['welcome_bg_color']      ?? null);
+    $welcomeTextColor     = $this->normalizeColor($_POST['welcome_text_color']    ?? '', $company['welcome_text_color']    ?? null);
 
     // Tempo médio (inteiros ou NULL)
     $avg_from = (isset($_POST['avg_delivery_min_from']) && $_POST['avg_delivery_min_from'] !== '')
@@ -142,8 +160,22 @@ class AdminSettingsController extends Controller {
     if ($errMsgs)     $_SESSION['flash_error'] = implode(' ', $errMsgs);
 
     // ----- UPDATE companies
-    $set  = "name=?, whatsapp=?, address=?, highlight_text=?, min_order=?, avg_delivery_min_from=?, avg_delivery_min_to=?";
-    $vals = [$name, $whatsapp, $address, $highlight, $min_order, $avg_from, $avg_to];
+    $set  = "name=?, whatsapp=?, address=?, highlight_text=?, min_order=?, avg_delivery_min_from=?, avg_delivery_min_to=?, header_text_color=?, header_logo_bg_color=?, group_title_bg_color=?, group_title_text_color=?, welcome_bg_color=?, welcome_text_color=?";
+    $vals = [
+      $name,
+      $whatsapp,
+      $address,
+      $highlight,
+      $min_order,
+      $avg_from,
+      $avg_to,
+      $headerTextColor,
+      $logoBgColor,
+      $groupTitleBgColor,
+      $groupTitleTextColor,
+      $welcomeBgColor,
+      $welcomeTextColor,
+    ];
 
     if ($newLogoPath)   { $set .= ", logo=?";   $vals[] = $newLogoPath; }
     if ($newBannerPath) { $set .= ", banner=?"; $vals[] = $newBannerPath; }

--- a/app/views/admin/settings/index.php
+++ b/app/views/admin/settings/index.php
@@ -55,6 +55,43 @@ ob_start(); ?>
     <textarea name="highlight_text" rows="3" class="border rounded-xl p-2"><?= e($company['highlight_text']) ?></textarea>
   </label>
 
+  <hr class="my-2">
+
+  <h2 class="text-lg font-semibold">Cores do cardápio</h2>
+  <p class="text-sm text-gray-600 mb-2">Personalize as cores principais do cabeçalho e das seções do cardápio.</p>
+
+  <div class="grid md:grid-cols-2 gap-3">
+    <label class="grid gap-1">
+      <span class="text-sm">Cor dos textos e botões do cabeçalho</span>
+      <input type="color" name="header_text_color" value="<?= e($company['header_text_color'] ?? '#ffffff') ?>" class="border rounded-xl p-2 h-12">
+    </label>
+
+    <label class="grid gap-1">
+      <span class="text-sm">Cor de fundo ao redor do logo</span>
+      <input type="color" name="header_logo_bg_color" value="<?= e($company['header_logo_bg_color'] ?? '#ffffff') ?>" class="border rounded-xl p-2 h-12">
+    </label>
+
+    <label class="grid gap-1">
+      <span class="text-sm">Cor de fundo do título dos grupos</span>
+      <input type="color" name="group_title_bg_color" value="<?= e($company['group_title_bg_color'] ?? '#facc15') ?>" class="border rounded-xl p-2 h-12">
+    </label>
+
+    <label class="grid gap-1">
+      <span class="text-sm">Cor do título dos grupos</span>
+      <input type="color" name="group_title_text_color" value="<?= e($company['group_title_text_color'] ?? '#000000') ?>" class="border rounded-xl p-2 h-12">
+    </label>
+
+    <label class="grid gap-1">
+      <span class="text-sm">Cor de fundo da mensagem de boas-vindas</span>
+      <input type="color" name="welcome_bg_color" value="<?= e($company['welcome_bg_color'] ?? '#6d28d9') ?>" class="border rounded-xl p-2 h-12">
+    </label>
+
+    <label class="grid gap-1">
+      <span class="text-sm">Cor do texto da mensagem de boas-vindas</span>
+      <input type="color" name="welcome_text_color" value="<?= e($company['welcome_text_color'] ?? '#ffffff') ?>" class="border rounded-xl p-2 h-12">
+    </label>
+  </div>
+
   <div class="grid md:grid-cols-2 gap-4">
     <div>
       <span class="text-sm block mb-1">Logo (quadrado) – jpg/png/webp</span>

--- a/app/views/public/home.php
+++ b/app/views/public/home.php
@@ -38,6 +38,17 @@ if (!function_exists('badgeNew')) {
   function badgeNew($p){ return is_new_product($p); }
 }
 
+function menu_color(array $company, string $key, string $default): string {
+  $val = $company[$key] ?? null;
+  if (is_string($val)) {
+    $val = trim($val);
+    if ($val !== '' && preg_match('/^#([0-9a-f]{3}|[0-9a-f]{6})$/i', $val)) {
+      return strtolower($val);
+    }
+  }
+  return $default;
+}
+
 /* Variáveis vindas do controller (com fallbacks para evitar notices) */
 $q              = $q              ?? '';
 $novidades      = $novidades      ?? [];
@@ -58,6 +69,13 @@ $bannerUrl = !empty($company['banner']) ? base_url($company['banner']) : null;
 if (session_status() !== PHP_SESSION_ACTIVE) @session_start();
 $customer = $_SESSION['customer'] ?? null;
 $showFooterMenu = true;
+
+$headerTextColor     = menu_color($company, 'header_text_color', '#ffffff');
+$logoBgColor         = menu_color($company, 'header_logo_bg_color', '#ffffff');
+$groupTitleBgColor   = menu_color($company, 'group_title_bg_color', '#facc15');
+$groupTitleTextColor = menu_color($company, 'group_title_text_color', '#000000');
+$welcomeBgColor      = menu_color($company, 'welcome_bg_color', '#6d28d9');
+$welcomeTextColor    = menu_color($company, 'welcome_text_color', '#ffffff');
 ?>
 <header>
   <style>
@@ -67,6 +85,17 @@ $showFooterMenu = true;
     .no-focus-ring:focus-within,
     .no-focus-ring:target { outline: none !important; box-shadow: none !important; }
     .no-focus-ring { -webkit-tap-highlight-color: transparent; }
+    .menu-header { color: <?= e($headerTextColor) ?>; }
+    .menu-header a,
+    .menu-header button { color: inherit; }
+    .menu-header .menu-header-btn {
+      color: <?= e($headerTextColor) ?>;
+      border-color: <?= e($headerTextColor) ?>;
+      background-color: transparent;
+    }
+    .menu-logo-ring { background-color: <?= e($logoBgColor) ?>; }
+    .group-title { background: <?= e($groupTitleBgColor) ?>; color: <?= e($groupTitleTextColor) ?>; }
+    .welcome-banner { background: <?= e($welcomeBgColor) ?>; color: <?= e($welcomeTextColor) ?>; }
   </style>
   <div class="rounded-2xl overflow-hidden">
     <?php if ($bannerUrl): ?>
@@ -78,9 +107,9 @@ $showFooterMenu = true;
       <div class="bg-purple-900 h-24"></div>
     <?php endif; ?>
 
-    <div class="bg-purple-900 text-white p-5 relative -mt-10 rounded-t-2xl no-focus-ring">
+    <div class="bg-purple-900 p-5 relative -mt-10 rounded-t-2xl no-focus-ring menu-header">
       <img src="<?= base_url($company['logo'] ?? 'assets/logo-placeholder.png') ?>"
-           class="w-24 h-24 rounded-full object-cover border-4 border-purple-700 bg-white absolute -top-10 right-6 pointer-events-none"
+           class="w-24 h-24 rounded-full object-cover border-4 border-purple-700 absolute -top-10 right-6 pointer-events-none menu-logo-ring"
            alt="<?= e($company['name'] ?? 'Logo') ?>">
       <div class="min-w-0 pr-28">
         <h1 class="text-2xl font-bold"><?= e($company['name'] ?? 'Empresa') ?></h1>
@@ -115,12 +144,12 @@ $showFooterMenu = true;
             <!-- Login ou saudação do cliente -->
             <?php if (!empty($customer) && isset($company['id']) && isset($customer['company_id']) && (int)$customer['company_id'] === (int)$company['id']): ?>
               <div class="flex items-center gap-2 w-full sm:w-auto mt-2 sm:mt-0 self-center">
-                <span class="px-2 py-0.5 rounded-lg bg-white text-purple-900 font-semibold">
+                <span class="px-2 py-0.5 rounded-lg border menu-header-btn font-semibold">
                   Olá, <?= e($customer['name'] ?? 'Cliente') ?>
                 </span>
                 <form method="post" action="<?= base_url(rawurlencode((string)$company['slug']).'/customer-logout') ?>" onsubmit="return confirm('Sair?')">
                   <?php if (function_exists('csrf_field')) { echo csrf_field(); } ?>
-                  <button class="px-2 py-0.5 rounded-lg border bg-white text-purple-900 font-semibold hover:bg-slate-50">Sair</button>
+                  <button class="px-2 py-0.5 rounded-lg border menu-header-btn font-semibold">Sair</button>
                 </form>
               </div>
             <?php else: ?>
@@ -128,7 +157,7 @@ $showFooterMenu = true;
                 <button
                   type="button"
                   id="btn-open-login"
-                  class="px-2 py-0.5 rounded-lg border bg-white text-purple-900 hover:bg-slate-50 font-semibold">
+                  class="px-2 py-0.5 rounded-lg border font-semibold menu-header-btn">
                   Entrar
                 </button>
               </div>
@@ -143,8 +172,8 @@ $showFooterMenu = true;
     </div>
 
     <?php if (!empty($company['highlight_text'])): ?>
-      <div class="bg-purple-100 p-4">
-        <p class="bg-purple-700 text-white p-3 rounded-xl text-sm">
+      <div class="p-4">
+        <p class="welcome-banner p-3 rounded-xl text-sm">
           <?= nl2br(e($company['highlight_text'])) ?>
         </p>
       </div>
@@ -344,7 +373,7 @@ $showFooterMenu = true;
 <!-- ======== BLOCOS NO TOPO ======== -->
 <?php if ($mostraNovidade): ?>
   <a id="novidades"></a>
-  <h2 class="text-xl font-bold bg-yellow-400 text-black inline-block px-3 py-1 rounded-lg mb-2">Novidades</h2>
+  <h2 class="text-xl font-bold group-title inline-block px-3 py-1 rounded-lg mb-2">Novidades</h2>
   <div class="grid gap-3 mb-6">
     <?php foreach ($novidades as $p): ?>
       <?php include __DIR__ . '/partials_card.php'; ?>
@@ -358,7 +387,7 @@ $showFooterMenu = true;
 
 <?php foreach ($categories as $c): ?>
   <a id="cat-<?= (int)$c['id'] ?>"></a>
-  <h2 class="text-xl font-bold bg-yellow-400 inline-block px-3 py-1 rounded-lg mb-2"><?= e($c['name'] ?? 'Categoria') ?></h2>
+  <h2 class="text-xl font-bold group-title inline-block px-3 py-1 rounded-lg mb-2"><?= e($c['name'] ?? 'Categoria') ?></h2>
   <?php $items = array_values(array_filter($products, fn($p)=> (int)($p['category_id'] ?? 0) === (int)$c['id'])); ?>
   <div class="grid gap-3 mb-6">
     <?php foreach ($items as $p): include __DIR__ . '/partials_card.php'; endforeach; ?>

--- a/database/menu_schema_with_customization.sql
+++ b/database/menu_schema_with_customization.sql
@@ -33,6 +33,12 @@ CREATE TABLE `companies` (
   `whatsapp` varchar(20) DEFAULT NULL,
   `address` varchar(255) DEFAULT NULL,
   `highlight_text` text DEFAULT NULL,
+  `header_text_color` varchar(9) DEFAULT NULL,
+  `header_logo_bg_color` varchar(9) DEFAULT NULL,
+  `group_title_bg_color` varchar(9) DEFAULT NULL,
+  `group_title_text_color` varchar(9) DEFAULT NULL,
+  `welcome_bg_color` varchar(9) DEFAULT NULL,
+  `welcome_text_color` varchar(9) DEFAULT NULL,
   `min_order` decimal(10,2) DEFAULT NULL,
   `avg_delivery_min_from` int(11) DEFAULT NULL,
   `avg_delivery_min_to` int(11) DEFAULT NULL,
@@ -42,8 +48,8 @@ CREATE TABLE `companies` (
   `created_at` datetime DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
-INSERT INTO `companies` (`id`, `slug`, `name`, `whatsapp`, `address`, `highlight_text`, `min_order`, `avg_delivery_min_from`, `avg_delivery_min_to`, `logo`, `banner`, `active`, `created_at`) VALUES
-(1, 'wollburger', 'Wollburger', '55', '', '', NULL, NULL, NULL, NULL, NULL, 1, '2025-09-11 01:38:16');
+INSERT INTO `companies` (`id`, `slug`, `name`, `whatsapp`, `address`, `highlight_text`, `header_text_color`, `header_logo_bg_color`, `group_title_bg_color`, `group_title_text_color`, `welcome_bg_color`, `welcome_text_color`, `min_order`, `avg_delivery_min_from`, `avg_delivery_min_to`, `logo`, `banner`, `active`, `created_at`) VALUES
+(1, 'wollburger', 'Wollburger', '55', '', '', '#ffffff', '#ffffff', '#facc15', '#000000', '#6d28d9', '#ffffff', NULL, NULL, NULL, NULL, NULL, 1, '2025-09-11 01:38:16');
 
 -- --------------------------------------------------------
 -- Estrutura da tabela `categories`


### PR DESCRIPTION
## Summary
- add configurable color fields to the admin settings form and persistence layer
- apply the chosen colors to the public menu header, group titles, and welcome message
- extend the sample schema with the new color columns and defaults

## Testing
- php -l app/controllers/AdminSettingsController.php
- php -l app/views/admin/settings/index.php
- php -l app/views/public/home.php

------
https://chatgpt.com/codex/tasks/task_e_68cfa8459684832ebe62568c39b5e9b0