### PR TITLE
Atualiza carregamento de imagens para diretório local

### DIFF
--- a/app/core/Helpers.php
+++ b/app/core/Helpers.php
@@ -18,6 +18,36 @@ function base_url(string $path = ''): string {
   return $p ? "$b/$p" : $b;
 }
 
+function upload_image_url($value, string $fallback = 'logo-placeholder.png'): string {
+  $filename = '';
+
+  if (is_string($value) || is_numeric($value)) {
+    $raw = trim((string)$value);
+    if ($raw !== '') {
+      $raw = str_replace('\\', '/', $raw);
+      $raw = explode('?', $raw, 2)[0];
+      $raw = explode('#', $raw, 2)[0];
+      $filename = basename($raw);
+    }
+  }
+
+  if ($filename === '' || $filename === '.' || $filename === '..') {
+    $fallback = trim((string)$fallback);
+    if ($fallback !== '') {
+      $fallback = str_replace('\\', '/', $fallback);
+      $fallback = explode('?', $fallback, 2)[0];
+      $fallback = explode('#', $fallback, 2)[0];
+      $filename = basename($fallback);
+    }
+  }
+
+  if ($filename === '' || $filename === '.' || $filename === '..') {
+    $filename = 'logo-placeholder.png';
+  }
+
+  return base_url('uploads/' . ltrim($filename, '/'));
+}
+
 function e($s) {
   return htmlspecialchars($s ?? '', ENT_QUOTES, 'UTF-8');
 }

--- a/app/views/admin/dashboard/index.php
+++ b/app/views/admin/dashboard/index.php
@@ -7,6 +7,22 @@ if (!function_exists('base_url')) {
     return $b . '/' . ltrim((string)$p, '/');
   }
 }
+if (!function_exists('upload_image_url')) {
+  function upload_image_url($value, string $fallback = 'logo-placeholder.png') {
+    $raw = is_string($value) || is_numeric($value) ? trim((string)$value) : '';
+    if ($raw === '') {
+      $raw = $fallback;
+    }
+    $raw = str_replace('\\', '/', (string)$raw);
+    $raw = explode('?', $raw, 2)[0];
+    $raw = explode('#', $raw, 2)[0];
+    $filename = basename($raw);
+    if ($filename === '' || $filename === '.' || $filename === '..') {
+      $filename = 'logo-placeholder.png';
+    }
+    return base_url('uploads/' . ltrim($filename, '/'));
+  }
+}
 
 // Normalizações seguras
 $company            = is_array($company ?? null) ? $company : [];
@@ -23,12 +39,12 @@ $publicSlug = rawurlencode((string)($company['slug'] ?? ''));
 $title      = "Dashboard - " . ($company['name'] ?? 'Empresa');
 
 // Logo com fallback
-$companyLogo = $company['logo'] ?? 'assets/logo-placeholder.png';
+$companyLogo = upload_image_url($company['logo'] ?? '');
 
 ob_start(); ?>
 
 <header class="flex items-center gap-3 mb-6">
-  <img src="<?= e(base_url($companyLogo)) ?>" class="w-12 h-12 rounded-xl object-cover" alt="Logo">
+  <img src="<?= e($companyLogo) ?>" class="w-12 h-12 rounded-xl object-cover" alt="<?= e($company['name'] ?? 'Logo') ?>">
   <div>
     <h1 class="text-xl font-bold"><?= e($company['name'] ?? '') ?></h1>
     <p class="text-sm text-gray-600">
@@ -142,12 +158,9 @@ ob_start(); ?>
     <ul class="divide-y">
       <?php $show = array_slice($products, 0, 8); ?>
       <?php foreach ($show as $p): ?>
+        <?php $productImage = upload_image_url($p['image'] ?? ''); ?>
         <li class="py-2 flex items-center gap-3">
-          <?php if (!empty($p['image'])): ?>
-            <img src="<?= e(base_url($p['image'])) ?>" class="w-10 h-10 object-cover rounded-lg" alt="">
-          <?php else: ?>
-            <div class="w-10 h-10 rounded-lg bg-slate-200"></div>
-          <?php endif; ?>
+          <img src="<?= e($productImage) ?>" class="w-10 h-10 object-cover rounded-lg" alt="<?= e($p['name'] ?? 'Produto') ?>">
           <div class="flex-1">
             <div class="font-medium text-sm"><?= e($p['name'] ?? '') ?></div>
             <div class="text-xs text-gray-500">

--- a/app/views/admin/ingredients/form.php
+++ b/app/views/admin/ingredients/form.php
@@ -135,7 +135,8 @@ ob_start(); ?>
         <span>Enviar imagem</span>
       </label>
       <?php if ($image): ?>
-        <img src="<?= e(base_url($image)) ?>" alt="" class="w-14 h-14 rounded-full object-cover border">
+        <?php $imageUrl = upload_image_url($image); ?>
+        <img src="<?= e($imageUrl) ?>" alt="<?= e($ingredient['name'] ?? 'Ingrediente') ?>" class="w-14 h-14 rounded-full object-cover border">
       <?php else: ?>
         <span class="text-xs text-slate-500">Sem imagem</span>
       <?php endif; ?>

--- a/app/views/admin/ingredients/index.php
+++ b/app/views/admin/ingredients/index.php
@@ -58,7 +58,8 @@ ob_start(); ?>
       <td class="p-3">
         <div class="flex items-center gap-3">
           <?php if (!empty($item['image_path'])): ?>
-            <img src="<?= e(base_url($item['image_path'])) ?>" alt="" class="w-10 h-10 rounded-full object-cover">
+            <?php $ingredientImage = upload_image_url($item['image_path']); ?>
+            <img src="<?= e($ingredientImage) ?>" alt="<?= e($item['name'] ?? 'Ingrediente') ?>" class="w-10 h-10 rounded-full object-cover">
           <?php else: ?>
             <div class="w-10 h-10 rounded-full bg-slate-200 grid place-items-center text-slate-500 text-xs">IMG</div>
           <?php endif; ?>

--- a/app/views/admin/products/form.php
+++ b/app/views/admin/products/form.php
@@ -151,9 +151,10 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
       </label>
       <div class="flex flex-col items-center gap-2">
         <span class="text-xs text-gray-500">Pré-visualização</span>
+        <?php $previewImage = upload_image_url($p['image'] ?? ''); ?>
         <img id="image-preview"
-             src="<?= !empty($p['image']) ? e(base_url($p['image'])) : e(base_url('assets/logo-placeholder.png')) ?>"
-             alt="Pré-visualização"
+             src="<?= e($previewImage) ?>"
+             alt="Pré-visualização de <?= e($p['name'] ?? 'produto') ?>"
              class="w-32 h-32 object-cover rounded-lg border">
       </div>
     </div>

--- a/app/views/admin/products/index.php
+++ b/app/views/admin/products/index.php
@@ -35,9 +35,8 @@ ob_start(); ?>
     foreach ($items as $p): ?>
     <tr class="border-t">
       <td class="p-3">
-        <?php if ($p['image']): ?>
-          <img src="<?= base_url($p['image']) ?>" class="w-12 h-12 object-cover rounded-lg">
-        <?php endif; ?>
+        <?php $productImage = upload_image_url($p['image'] ?? ''); ?>
+        <img src="<?= e($productImage) ?>" class="w-12 h-12 object-cover rounded-lg" alt="<?= e($p['name']) ?>">
       </td>
       <td class="p-3"><?= e($p['name']) ?></td>
       <td class="p-3"><?= e($byId[$p['category_id']] ?? '-') ?></td>

--- a/app/views/admin/settings/index.php
+++ b/app/views/admin/settings/index.php
@@ -141,7 +141,8 @@ ob_start(); ?>
     <div>
       <span class="text-sm block mb-1">Logo (quadrado) – jpg/png/webp</span>
       <?php if (!empty($company['logo'])): ?>
-        <img src="<?= base_url($company['logo']) ?>" class="w-20 h-20 object-cover rounded-xl mb-2" alt="Logo atual">
+        <?php $logoImage = upload_image_url($company['logo']); ?>
+        <img src="<?= e($logoImage) ?>" class="w-20 h-20 object-cover rounded-xl mb-2" alt="Logo atual">
       <?php endif; ?>
       <input type="file" name="logo" accept=".jpg,.jpeg,.png,.webp" class="border rounded-xl p-2 w-full">
     </div>
@@ -149,7 +150,8 @@ ob_start(); ?>
     <div>
       <span class="text-sm block mb-1">Banner (largura) – jpg/png/webp</span>
       <?php if (!empty($company['banner'])): ?>
-        <img src="<?= base_url($company['banner']) ?>" class="w-full max-w-md h-24 object-cover rounded-xl mb-2" alt="Banner atual">
+        <?php $bannerImage = upload_image_url($company['banner']); ?>
+        <img src="<?= e($bannerImage) ?>" class="w-full max-w-md h-24 object-cover rounded-xl mb-2" alt="Banner atual">
       <?php endif; ?>
       <input type="file" name="banner" accept=".jpg,.jpeg,.png,.webp" class="border rounded-xl p-2 w-full">
     </div>

--- a/app/views/public/customization.php
+++ b/app/views/public/customization.php
@@ -45,6 +45,7 @@ foreach (($mods ?? []) as $gIndex => $g) {
 // URLs
 $backUrl = base_url($slug . '/produto/' . $pId);
 $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
+$thumbFallback = upload_image_url(null);
 ?>
 <!doctype html>
 <html lang="pt-br">
@@ -153,13 +154,15 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
           ?>
           <?php foreach ($items as $ii => $it):
             $isSel = ($ii === $selectedIndex);
-            $img   = $it['img'] ?? null; ?>
+            $imgRaw = $it['img'] ?? '';
+            $thumbSrc = upload_image_url($imgRaw);
+            $optName = $it['name'] ?? $it['label'] ?? ('Opção '.($ii+1));
+          ?>
             <div class="row radio" data-radio="g<?= (int)$gi ?>" data-id="<?= (int)$ii ?>">
               <div class="thumb">
-                <img src="<?= e($img ?: 'https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+') ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'">
+                <img src="<?= e($thumbSrc) ?>" alt="<?= e($optName) ?>" onerror="this.src='<?= e($thumbFallback) ?>'">
               </div>
               <div class="info">
-                <?php $optName = $it['name'] ?? $it['label'] ?? ('Opção '.($ii+1)); ?>
                 <div class="name"><?= e($optName) ?></div>
                 <?php $sale = isset($it['sale_price']) ? (float)$it['sale_price'] : 0.0; ?>
                 <?php if ($sale > 0): ?>
@@ -184,16 +187,17 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
           ?>
           <div class="list choice" data-group="g<?= (int)$gi ?>" data-min="<?= (int)$minSel ?>" data-max="<?= (int)$maxSel ?>">
             <?php foreach ($items as $ii => $it):
-              $img   = $it['img'] ?? null;
+              $imgRaw = $it['img'] ?? '';
               $sale  = isset($it['sale_price']) ? (float)$it['sale_price'] : (float)($it['delta'] ?? 0);
               $isSel = !empty($it['selected']) || !empty($it['default']);
+              $thumbSrc = upload_image_url($imgRaw);
+              $optName = $it['name'] ?? $it['label'] ?? ('Opção '.($ii+1));
             ?>
               <div class="row checkbox" data-group="g<?= (int)$gi ?>" data-id="<?= (int)$ii ?>">
                 <div class="thumb">
-                  <img src="<?= e($img ?: 'https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+') ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'">
+                  <img src="<?= e($thumbSrc) ?>" alt="<?= e($optName) ?>" onerror="this.src='<?= e($thumbFallback) ?>'">
                 </div>
                 <div class="info">
-                  <?php $optName = $it['name'] ?? $it['label'] ?? ('Opção '.($ii+1)); ?>
                   <div class="name"><?= e($optName) ?></div>
                   <?php if ($sale > 0): ?>
                     <div class="price"><?= price_br($sale) ?></div>
@@ -212,18 +216,19 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
         <?php else: ?>
           <div class="list" aria-label="<?= e($gName) ?>">
             <?php foreach ($items as $ii => $it):
-              $img   = $it['img'] ?? null;
+              $imgRaw = $it['img'] ?? '';
               $min   = isset($it['min']) ? (int)$it['min'] : 0;
               $max   = isset($it['max']) ? (int)$it['max'] : 5;
               $qty   = isset($it['qty']) ? (int)$it['qty'] : (!empty($it['default']) ? (int)($it['default_qty'] ?? $min) : $min);
               $sale  = isset($it['sale_price']) ? (float)$it['sale_price'] : (float)($it['delta'] ?? 0);
+              $thumbSrc = upload_image_url($imgRaw);
+              $itemName = $it['name'] ?? $it['label'] ?? ('Item '.($ii+1));
             ?>
               <div class="row" data-id="<?= (int)$ii ?>" data-min="<?= $min ?>" data-max="<?= $max ?>">
                 <div class="thumb">
-                  <img src="<?= e($img ?: 'https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+') ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'">
+                  <img src="<?= e($thumbSrc) ?>" alt="<?= e($itemName) ?>" onerror="this.src='<?= e($thumbFallback) ?>'">
                 </div>
                 <div class="info">
-                  <?php $itemName = $it['name'] ?? $it['label'] ?? ('Item '.($ii+1)); ?>
                   <div class="name"><?= e($itemName) ?></div>
                   <?php if ($sale > 0): ?>
                     <div class="price"><?= price_br($sale) ?></div>

--- a/app/views/public/home.php
+++ b/app/views/public/home.php
@@ -67,7 +67,8 @@ $company        = $company        ?? [];
 /* Flags: controller decide; view só obedece */
 $mostraNovidade = isset($mostraNovidade) ? (bool)$mostraNovidade : (count($novidades) > 0);
 
-$bannerUrl = !empty($company['banner']) ? base_url($company['banner']) : null;
+$bannerUrl = !empty($company['banner']) ? upload_image_url($company['banner']) : null;
+$logoUrl = upload_image_url($company['logo'] ?? '');
 
 /* Sessão do cliente (se existir) */
 if (session_status() !== PHP_SESSION_ACTIVE) @session_start();
@@ -157,7 +158,7 @@ $showFooterMenu = true;
   <div class="rounded-2xl overflow-hidden">
     <?php if ($bannerUrl): ?>
       <div class="relative">
-        <img src="<?= $bannerUrl ?>" class="w-full h-36 md:h-48 object-cover" alt="Banner">
+        <img src="<?= e($bannerUrl) ?>" class="w-full h-36 md:h-48 object-cover" alt="Banner">
         <div class="absolute inset-0 bg-black/30"></div>
       </div>
     <?php else: ?>
@@ -165,7 +166,7 @@ $showFooterMenu = true;
     <?php endif; ?>
 
     <div class="p-5 relative -mt-10 rounded-2xl no-focus-ring menu-header">
-      <img src="<?= base_url($company['logo'] ?? 'assets/logo-placeholder.png') ?>"
+      <img src="<?= e($logoUrl) ?>"
            class="w-24 h-24 rounded-full object-cover border-4 absolute -top-10 right-6 pointer-events-none"
            style="background-color: <?= e($logoBorderColor) ?>; border-color: <?= e($logoBorderColor) ?>;"
            alt="<?= e($company['name'] ?? 'Logo') ?>">

--- a/app/views/public/partials_card.php
+++ b/app/views/public/partials_card.php
@@ -1,6 +1,7 @@
 <a href="<?= base_url(rawurlencode((string)($company['slug'] ?? '')) . '/produto/' . (int)$p['id']) ?>" class="block">
   <div class="rounded-2xl shadow p-4 bg-white border flex gap-3 hover:bg-gray-50">
-    <img src="<?= base_url($p['image'] ?: 'assets/logo-placeholder.png') ?>"
+    <?php $cardImage = upload_image_url($p['image'] ?? ''); ?>
+    <img src="<?= e($cardImage) ?>"
          alt="<?= e($p['name']) ?>"
          class="w-24 h-24 object-cover rounded-xl">
 

--- a/app/views/public/product.php
+++ b/app/views/public/product.php
@@ -126,9 +126,9 @@ $addToCartUrl  = base_url($slug . '/orders/add');                               
     </a>
 
     <?php
-      $imagePath = trim((string)($product['image'] ?? ''));
-      $imgSrc = base_url($imagePath !== '' ? $imagePath : 'assets/logo-placeholder.png');
-      $imgAlt = $imagePath !== '' ? ($product['name'] ?? 'Produto') : 'Imagem do produto';
+      $imagePath = $product['image'] ?? '';
+      $imgSrc = upload_image_url($imagePath);
+      $imgAlt = $product['name'] ?? 'Imagem do produto';
     ?>
     <div class="hero-toggle" role="group" aria-label="Modo de exibição da imagem">
       <button type="button" data-fit="contain" aria-pressed="true">Contain</button>
@@ -236,14 +236,15 @@ $addToCartUrl  = base_url($slug . '/orders/add');                               
           <?php foreach ($items as $ii => $opt): ?>
             <?php
               $isDefault = !empty($opt['default']);
-              $img = (string)($opt['image'] ?? '');
+              $img = $opt['image'] ?? '';
               $optPrice = (isset($opt['delta']) ? (float)$opt['delta'] : 0.0);
               $priceLabel = $optPrice != 0.0 ? price_br($optPrice) : 'Incluído';
+              $comboImg = upload_image_url($img);
+              $comboAlt = $opt['name'] ?? '';
             ?>
             <div class="choice <?= $isDefault ? 'sel' : '' ?>" data-group="<?= (int)$gi ?>" data-id="<?= (int)($opt['id'] ?? 0) ?>">
               <button type="button" class="ring" aria-pressed="<?= $isDefault ? 'true':'false' ?>">
-                <?php $comboImg = $img !== '' ? base_url($img) : base_url('assets/logo-placeholder.png'); ?>
-                <img src="<?= e($comboImg) ?>" alt="<?= e($opt['name] ?? '') ?>">
+                <img src="<?= e($comboImg) ?>" alt="<?= e($comboAlt) ?>">
                 <span class="mark" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="none"><path d="M20 6L9 17l-5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
                 </span>


### PR DESCRIPTION
## Summary
- adiciona helper upload_image_url para normalizar caminhos de imagens no diretório uploads
- atualiza todas as views públicas e administrativas para usar imagens locais com fallback no uploads
- substitui placeholders externos por arquivo local e mantém textos alternativos dinâmicos

## Testing
- php -l app/core/Helpers.php app/views/admin/dashboard/index.php app/views/admin/ingredients/form.php app/views/admin/ingredients/index.php app/views/admin/products/form.php app/views/admin/products/index.php app/views/admin/settings/index.php app/views/public/customization.php app/views/public/home.php app/views/public/partials_card.php app/views/public/product.php

------
https://chatgpt.com/codex/tasks/task_e_68d0c365b798832ea58e85e0bc047a40