### PR TITLE
Atualiza imagens para uso local

### DIFF
--- a/app/views/admin/dashboard/index.php
+++ b/app/views/admin/dashboard/index.php
@@ -23,7 +23,12 @@ $publicSlug = rawurlencode((string)($company['slug'] ?? ''));
 $title      = "Dashboard - " . ($company['name'] ?? 'Empresa');
 
 // Logo com fallback
-$companyLogo = $company['logo'] ?? 'assets/logo-placeholder.png';
+$companyLogoRaw = $company['logo'] ?? '';
+$companyLogoFile = basename((string)$companyLogoRaw);
+if ($companyLogoFile === '' || $companyLogoFile === '.' || $companyLogoFile === '..') {
+  $companyLogoFile = 'logo-placeholder.png';
+}
+$companyLogo = 'uploads/' . $companyLogoFile;
 
 ob_start(); ?>
 
@@ -143,9 +148,20 @@ ob_start(); ?>
       <?php $show = array_slice($products, 0, 8); ?>
       <?php foreach ($show as $p): ?>
         <li class="py-2 flex items-center gap-3">
-          <?php if (!empty($p['image'])): ?>
-            <img src="<?= e(base_url($p['image'])) ?>" class="w-10 h-10 object-cover rounded-lg" alt="">
-          <?php else: ?>
+          <?php
+            $dashImageShown = false;
+            if (!empty($p['image'])) {
+              $dashImgFile = basename((string)$p['image']);
+              if ($dashImgFile !== '' && $dashImgFile !== '.' && $dashImgFile !== '..') {
+                $dashImgSrc = base_url('uploads/' . $dashImgFile);
+                $dashImageShown = true;
+          ?>
+            <img src="<?= e($dashImgSrc) ?>" class="w-10 h-10 object-cover rounded-lg" alt="<?= e($p['name'] ?? '') ?>">
+          <?php
+              }
+            }
+            if (!$dashImageShown):
+          ?>
             <div class="w-10 h-10 rounded-lg bg-slate-200"></div>
           <?php endif; ?>
           <div class="flex-1">

--- a/app/views/admin/ingredients/form.php
+++ b/app/views/admin/ingredients/form.php
@@ -7,6 +7,13 @@ $action  = $editing
   : 'admin/' . $slug . '/ingredients';
 
 $image = $ingredient['image_path'] ?? null;
+$imageSrc = null;
+if (!empty($image)) {
+  $imageFile = basename((string)$image);
+  if ($imageFile !== '' && $imageFile !== '.' && $imageFile !== '..') {
+    $imageSrc = base_url('uploads/' . $imageFile);
+  }
+}
 
 $unitOptions = [
   ['value' => 'un', 'label' => 'Unidade (un)'],
@@ -134,8 +141,8 @@ ob_start(); ?>
         <input type="file" name="image" accept="image/*" class="hidden">
         <span>Enviar imagem</span>
       </label>
-      <?php if ($image): ?>
-        <img src="<?= e(base_url($image)) ?>" alt="" class="w-14 h-14 rounded-full object-cover border">
+      <?php if ($imageSrc): ?>
+        <img src="<?= e($imageSrc) ?>" alt="" class="w-14 h-14 rounded-full object-cover border">
       <?php else: ?>
         <span class="text-xs text-slate-500">Sem imagem</span>
       <?php endif; ?>

--- a/app/views/admin/ingredients/index.php
+++ b/app/views/admin/ingredients/index.php
@@ -57,9 +57,20 @@ ob_start(); ?>
     <tr class="border-t">
       <td class="p-3">
         <div class="flex items-center gap-3">
-          <?php if (!empty($item['image_path'])): ?>
-            <img src="<?= e(base_url($item['image_path'])) ?>" alt="" class="w-10 h-10 rounded-full object-cover">
-          <?php else: ?>
+          <?php
+            $ingredientImageShown = false;
+            if (!empty($item['image_path'])) {
+              $ingredientImgFile = basename((string)$item['image_path']);
+              if ($ingredientImgFile !== '' && $ingredientImgFile !== '.' && $ingredientImgFile !== '..') {
+                $ingredientImgSrc = base_url('uploads/' . $ingredientImgFile);
+                $ingredientImageShown = true;
+          ?>
+            <img src="<?= e($ingredientImgSrc) ?>" alt="" class="w-10 h-10 rounded-full object-cover">
+          <?php
+              }
+            }
+            if (!$ingredientImageShown):
+          ?>
             <div class="w-10 h-10 rounded-full bg-slate-200 grid place-items-center text-slate-500 text-xs">IMG</div>
           <?php endif; ?>
           <div>

--- a/app/views/admin/products/form.php
+++ b/app/views/admin/products/form.php
@@ -151,8 +151,16 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
       </label>
       <div class="flex flex-col items-center gap-2">
         <span class="text-xs text-gray-500">Pré-visualização</span>
+        <?php
+          $previewRaw = $p['image'] ?? '';
+          $previewFile = basename((string)$previewRaw);
+          if ($previewFile === '' || $previewFile === '.' || $previewFile === '..') {
+            $previewFile = 'logo-placeholder.png';
+          }
+          $previewSrc = base_url('uploads/' . $previewFile);
+        ?>
         <img id="image-preview"
-             src="<?= !empty($p['image']) ? e(base_url($p['image'])) : e(base_url('assets/logo-placeholder.png')) ?>"
+             src="<?= e($previewSrc) ?>"
              alt="Pré-visualização"
              class="w-32 h-32 object-cover rounded-lg border">
       </div>

--- a/app/views/admin/products/index.php
+++ b/app/views/admin/products/index.php
@@ -35,8 +35,17 @@ ob_start(); ?>
     foreach ($items as $p): ?>
     <tr class="border-t">
       <td class="p-3">
-        <?php if ($p['image']): ?>
-          <img src="<?= base_url($p['image']) ?>" class="w-12 h-12 object-cover rounded-lg">
+        <?php
+          $prodImgSrc = null;
+          if (!empty($p['image'])) {
+            $prodImgFile = basename((string)$p['image']);
+            if ($prodImgFile !== '' && $prodImgFile !== '.' && $prodImgFile !== '..') {
+              $prodImgSrc = base_url('uploads/' . $prodImgFile);
+            }
+          }
+          if ($prodImgSrc):
+        ?>
+          <img src="<?= e($prodImgSrc) ?>" class="w-12 h-12 object-cover rounded-lg" alt="<?= e($p['name']) ?>">
         <?php endif; ?>
       </td>
       <td class="p-3"><?= e($p['name']) ?></td>

--- a/app/views/admin/settings/index.php
+++ b/app/views/admin/settings/index.php
@@ -37,6 +37,22 @@ $colorValues = [];
 foreach ($colorDefaults as $key => $default) {
   $colorValues[$key] = settings_color_value($company[$key] ?? '', $default);
 }
+
+$logoSrc = null;
+if (!empty($company['logo'])) {
+  $logoFile = basename((string)$company['logo']);
+  if ($logoFile !== '' && $logoFile !== '.' && $logoFile !== '..') {
+    $logoSrc = base_url('uploads/' . $logoFile);
+  }
+}
+
+$bannerSrc = null;
+if (!empty($company['banner'])) {
+  $bannerFile = basename((string)$company['banner']);
+  if ($bannerFile !== '' && $bannerFile !== '.' && $bannerFile !== '..') {
+    $bannerSrc = base_url('uploads/' . $bannerFile);
+  }
+}
 ob_start(); ?>
 <h1 class="text-2xl font-bold mb-4">Configurações gerais</h1>
 
@@ -140,16 +156,16 @@ ob_start(); ?>
   <div class="grid md:grid-cols-2 gap-4">
     <div>
       <span class="text-sm block mb-1">Logo (quadrado) – jpg/png/webp</span>
-      <?php if (!empty($company['logo'])): ?>
-        <img src="<?= base_url($company['logo']) ?>" class="w-20 h-20 object-cover rounded-xl mb-2" alt="Logo atual">
+      <?php if ($logoSrc): ?>
+        <img src="<?= e($logoSrc) ?>" class="w-20 h-20 object-cover rounded-xl mb-2" alt="Logo atual">
       <?php endif; ?>
       <input type="file" name="logo" accept=".jpg,.jpeg,.png,.webp" class="border rounded-xl p-2 w-full">
     </div>
 
     <div>
       <span class="text-sm block mb-1">Banner (largura) – jpg/png/webp</span>
-      <?php if (!empty($company['banner'])): ?>
-        <img src="<?= base_url($company['banner']) ?>" class="w-full max-w-md h-24 object-cover rounded-xl mb-2" alt="Banner atual">
+      <?php if ($bannerSrc): ?>
+        <img src="<?= e($bannerSrc) ?>" class="w-full max-w-md h-24 object-cover rounded-xl mb-2" alt="Banner atual">
       <?php endif; ?>
       <input type="file" name="banner" accept=".jpg,.jpeg,.png,.webp" class="border rounded-xl p-2 w-full">
     </div>

--- a/app/views/public/customization.php
+++ b/app/views/public/customization.php
@@ -45,6 +45,7 @@ foreach (($mods ?? []) as $gIndex => $g) {
 // URLs
 $backUrl = base_url($slug . '/produto/' . $pId);
 $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
+$uploadPlaceholder = base_url('uploads/logo-placeholder.png');
 ?>
 <!doctype html>
 <html lang="pt-br">
@@ -156,7 +157,14 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
             $img   = $it['img'] ?? null; ?>
             <div class="row radio" data-radio="g<?= (int)$gi ?>" data-id="<?= (int)$ii ?>">
               <div class="thumb">
-                <img src="<?= e($img ?: 'https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+') ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'">
+                <?php
+                  $optImgRaw = $img ?? '';
+                  $optImgFile = basename((string)$optImgRaw);
+                  $optImgSrc = ($optImgFile !== '' && $optImgFile !== '.' && $optImgFile !== '..')
+                    ? base_url('uploads/' . $optImgFile)
+                    : $uploadPlaceholder;
+                ?>
+                <img src="<?= e($optImgSrc) ?>" alt="" onerror="this.src='<?= e($uploadPlaceholder) ?>'">
               </div>
               <div class="info">
                 <?php $optName = $it['name'] ?? $it['label'] ?? ('Opção '.($ii+1)); ?>
@@ -190,7 +198,14 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
             ?>
               <div class="row checkbox" data-group="g<?= (int)$gi ?>" data-id="<?= (int)$ii ?>">
                 <div class="thumb">
-                  <img src="<?= e($img ?: 'https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+') ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'">
+                  <?php
+                    $choiceImgRaw = $img ?? '';
+                    $choiceImgFile = basename((string)$choiceImgRaw);
+                    $choiceImgSrc = ($choiceImgFile !== '' && $choiceImgFile !== '.' && $choiceImgFile !== '..')
+                      ? base_url('uploads/' . $choiceImgFile)
+                      : $uploadPlaceholder;
+                  ?>
+                  <img src="<?= e($choiceImgSrc) ?>" alt="" onerror="this.src='<?= e($uploadPlaceholder) ?>'">
                 </div>
                 <div class="info">
                   <?php $optName = $it['name'] ?? $it['label'] ?? ('Opção '.($ii+1)); ?>
@@ -220,7 +235,14 @@ $saveUrl = base_url($slug . '/produto/' . $pId . '/customizar/salvar');
             ?>
               <div class="row" data-id="<?= (int)$ii ?>" data-min="<?= $min ?>" data-max="<?= $max ?>">
                 <div class="thumb">
-                  <img src="<?= e($img ?: 'https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+') ?>" alt="" onerror="this.src='https://dummyimage.com/80x80/f3f4f6/aaa.png&text=+'">
+                  <?php
+                    $rowImgRaw = $img ?? '';
+                    $rowImgFile = basename((string)$rowImgRaw);
+                    $rowImgSrc = ($rowImgFile !== '' && $rowImgFile !== '.' && $rowImgFile !== '..')
+                      ? base_url('uploads/' . $rowImgFile)
+                      : $uploadPlaceholder;
+                  ?>
+                  <img src="<?= e($rowImgSrc) ?>" alt="" onerror="this.src='<?= e($uploadPlaceholder) ?>'">
                 </div>
                 <div class="info">
                   <?php $itemName = $it['name'] ?? $it['label'] ?? ('Item '.($ii+1)); ?>

--- a/app/views/public/home.php
+++ b/app/views/public/home.php
@@ -67,7 +67,18 @@ $company        = $company        ?? [];
 /* Flags: controller decide; view só obedece */
 $mostraNovidade = isset($mostraNovidade) ? (bool)$mostraNovidade : (count($novidades) > 0);
 
-$bannerUrl = !empty($company['banner']) ? base_url($company['banner']) : null;
+$logoRaw = $company['logo'] ?? '';
+$logoFile = basename((string)$logoRaw);
+if ($logoFile === '' || $logoFile === '.' || $logoFile === '..') {
+  $logoFile = 'logo-placeholder.png';
+}
+$logoSrc = base_url('uploads/' . $logoFile);
+
+$bannerRaw = $company['banner'] ?? '';
+$bannerFile = basename((string)$bannerRaw);
+$bannerUrl = $bannerFile !== '' && $bannerFile !== '.' && $bannerFile !== '..'
+  ? base_url('uploads/' . $bannerFile)
+  : null;
 
 /* Sessão do cliente (se existir) */
 if (session_status() !== PHP_SESSION_ACTIVE) @session_start();
@@ -157,7 +168,7 @@ $showFooterMenu = true;
   <div class="rounded-2xl overflow-hidden">
     <?php if ($bannerUrl): ?>
       <div class="relative">
-        <img src="<?= $bannerUrl ?>" class="w-full h-36 md:h-48 object-cover" alt="Banner">
+        <img src="<?= e($bannerUrl) ?>" class="w-full h-36 md:h-48 object-cover" alt="Banner">
         <div class="absolute inset-0 bg-black/30"></div>
       </div>
     <?php else: ?>
@@ -165,7 +176,7 @@ $showFooterMenu = true;
     <?php endif; ?>
 
     <div class="p-5 relative -mt-10 rounded-2xl no-focus-ring menu-header">
-      <img src="<?= base_url($company['logo'] ?? 'assets/logo-placeholder.png') ?>"
+      <img src="<?= e($logoSrc) ?>"
            class="w-24 h-24 rounded-full object-cover border-4 absolute -top-10 right-6 pointer-events-none"
            style="background-color: <?= e($logoBorderColor) ?>; border-color: <?= e($logoBorderColor) ?>;"
            alt="<?= e($company['name'] ?? 'Logo') ?>">

--- a/app/views/public/partials_card.php
+++ b/app/views/public/partials_card.php
@@ -1,6 +1,14 @@
 <a href="<?= base_url(rawurlencode((string)($company['slug'] ?? '')) . '/produto/' . (int)$p['id']) ?>" class="block">
   <div class="rounded-2xl shadow p-4 bg-white border flex gap-3 hover:bg-gray-50">
-    <img src="<?= base_url($p['image'] ?: 'assets/logo-placeholder.png') ?>"
+    <?php
+      $productImgRaw = $p['image'] ?? '';
+      $productImgFile = basename((string)$productImgRaw);
+      if ($productImgFile === '' || $productImgFile === '.' || $productImgFile === '..') {
+        $productImgFile = 'logo-placeholder.png';
+      }
+      $productImgSrc = base_url('uploads/' . $productImgFile);
+    ?>
+    <img src="<?= e($productImgSrc) ?>"
          alt="<?= e($p['name']) ?>"
          class="w-24 h-24 object-cover rounded-xl">
 

--- a/app/views/public/product.php
+++ b/app/views/public/product.php
@@ -24,6 +24,7 @@ $isCombo = (isset($product['type']) && $product['type'] === 'combo' && !empty($c
 /** URLs (ajuste às suas rotas reais) */
 $customizeBase = base_url($slug . '/produto/' . $pId . '/customizar');          // GET (tela de customização)
 $addToCartUrl  = base_url($slug . '/orders/add');                                // POST (adiciona ao carrinho)
+$uploadPlaceholder = base_url('uploads/logo-placeholder.png');
 ?>
 <!doctype html>
 <html lang="pt-br">
@@ -127,7 +128,12 @@ $addToCartUrl  = base_url($slug . '/orders/add');                               
 
     <?php
       $imagePath = trim((string)($product['image'] ?? ''));
-      $imgSrc = base_url($imagePath !== '' ? $imagePath : 'assets/logo-placeholder.png');
+      $imageFile = basename($imagePath);
+      if ($imageFile === '' || $imageFile === '.' || $imageFile === '..') {
+        $imgSrc = $uploadPlaceholder;
+      } else {
+        $imgSrc = base_url('uploads/' . $imageFile);
+      }
       $imgAlt = $imagePath !== '' ? ($product['name'] ?? 'Produto') : 'Imagem do produto';
     ?>
     <div class="hero-toggle" role="group" aria-label="Modo de exibição da imagem">
@@ -242,8 +248,15 @@ $addToCartUrl  = base_url($slug . '/orders/add');                               
             ?>
             <div class="choice <?= $isDefault ? 'sel' : '' ?>" data-group="<?= (int)$gi ?>" data-id="<?= (int)($opt['id'] ?? 0) ?>">
               <button type="button" class="ring" aria-pressed="<?= $isDefault ? 'true':'false' ?>">
-                <?php $comboImg = $img !== '' ? base_url($img) : base_url('assets/logo-placeholder.png'); ?>
-                <img src="<?= e($comboImg) ?>" alt="<?= e($opt['name] ?? '') ?>">
+                <?php
+                  $comboImgFile = basename($img);
+                  if ($comboImgFile === '' || $comboImgFile === '.' || $comboImgFile === '..') {
+                    $comboImg = $uploadPlaceholder;
+                  } else {
+                    $comboImg = base_url('uploads/' . $comboImgFile);
+                  }
+                ?>
+                <img src="<?= e($comboImg) ?>" alt="<?= e($opt['name'] ?? '') ?>">
                 <span class="mark" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="none"><path d="M20 6L9 17l-5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
                 </span>


### PR DESCRIPTION
## Summary
- atualiza as views públicas para que produtos, combos e banners carreguem imagens a partir de `uploads` com fallback local
- ajusta telas administrativas para normalizar caminhos de logo, banner, produtos e ingredientes usando arquivos do diretório `uploads`
- adiciona o placeholder de logo na pasta `uploads` para servir como imagem padrão

## Testing
- for file in app/views/admin/dashboard/index.php \
 app/views/admin/ingredients/form.php \
 app/views/admin/ingredients/index.php \
 app/views/admin/products/form.php \
 app/views/admin/products/index.php \
 app/views/admin/settings/index.php \
 app/views/public/customization.php \
 app/views/public/home.php \
 app/views/public/partials_card.php \
 app/views/public/product.php; do php -l "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68d0c365b798832ea58e85e0bc047a40