### PR TITLE
Handle default company routes and dynamic base URL

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -4,6 +4,7 @@ return [
   'env' => 'local',
   'debug' => true,
   'base_url' => null, // será detectado automaticamente se vazio
+  'default_company_slug' => null,
   'session_name' => 'mm_session',
   'timezone' => 'America/Sao_Paulo',
 

--- a/app/core/Auth.php
+++ b/app/core/Auth.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . '/Helpers.php';
+require_once __DIR__ . '/../models/Company.php';
+
 class Auth {
   public static function start(): void {
     $cfg = config();
@@ -38,10 +41,21 @@ class Auth {
 
   /** Exige admin logado (redireciona pro login) */
   public static function requireAdmin(): void {
-    if (!self::checkAdmin()) {
-      header("Location: " . base_url("admin/login"));
-      exit;
+    if (self::checkAdmin()) {
+      return;
     }
+
+    $slug = self::activeCompanySlug();
+    if (!$slug) {
+      $slug = Company::defaultSlug();
+    }
+
+    if ($slug) {
+      header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login'));
+    } else {
+      header('Location: ' . base_url('admin/login'));
+    }
+    exit;
   }
 
   /** company_id padrão do usuário (pode ser null para root) */

--- a/app/models/Company.php
+++ b/app/models/Company.php
@@ -4,6 +4,34 @@ require_once __DIR__ . '/../config/db.php';
 
 class Company
 {
+    /** Retorna o slug padrão configurado ou a primeira empresa ativa */
+    public static function defaultSlug(): ?string {
+        static $cached = false;
+        static $value = null;
+
+        if ($cached) {
+            return $value;
+        }
+
+        $cached = true;
+
+        $cfg = config('default_company_slug');
+        if (is_string($cfg) && trim($cfg) !== '') {
+            $value = trim($cfg);
+            return $value;
+        }
+
+        $st = db()->prepare("SELECT slug FROM companies WHERE active = 1 ORDER BY id ASC LIMIT 1");
+        if ($st->execute()) {
+            $slug = $st->fetchColumn();
+            if (is_string($slug) && $slug !== '') {
+                $value = $slug;
+            }
+        }
+
+        return $value;
+    }
+
     /** Busca empresa pelo slug (url amigável) */
     public static function findBySlug(string $slug): ?array {
         $st = db()->prepare("SELECT * FROM companies WHERE slug = ? LIMIT 1");

--- a/public/index.php
+++ b/public/index.php
@@ -6,6 +6,10 @@ require_once __DIR__ . '/../app/core/Router.php';
 require_once __DIR__ . '/../app/core/Controller.php';
 require_once __DIR__ . '/../app/config/db.php';
 
+if (!defined('APP_WEBROOT')) {
+  define('APP_WEBROOT', '');
+}
+
 $router = new Router();
 
 // (Opcional) Handlers de erro/404 se o Router suportar

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,73 @@
 <?php
 // routes/web.php
 
+require_once __DIR__ . '/../app/models/Company.php';
+
+/** Resolve o slug padrão configurado ou a primeira empresa ativa */
+if (!function_exists('resolve_default_company_slug')) {
+  function resolve_default_company_slug(): ?string {
+    return Company::defaultSlug();
+  }
+}
+
+/** Renderiza o cardápio público para a empresa padrão */
+if (!function_exists('render_default_menu')) {
+  function render_default_menu(): void {
+    $slug = resolve_default_company_slug();
+    if (!$slug) {
+      http_response_code(404);
+      echo 'Cardápio não configurado.';
+      return;
+    }
+
+    require_once __DIR__ . '/../app/controllers/PublicHomeController.php';
+    $controller = new PublicHomeController();
+    $controller->index(['slug' => $slug]);
+  }
+}
+
+/* ========= Rotas sem slug explícito ========= */
+$router->get('/', function () {
+  render_default_menu();
+});
+
+$router->get('/cardapio', function () {
+  render_default_menu();
+});
+
+$router->get('/dashboard', function () {
+  $slug = resolve_default_company_slug();
+  if (!$slug) {
+    http_response_code(404);
+    echo 'Empresa não configurada.';
+    return;
+  }
+  header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/dashboard'));
+  exit;
+});
+
+$router->get('/admin', function () {
+  $slug = resolve_default_company_slug();
+  if (!$slug) {
+    http_response_code(404);
+    echo 'Empresa não configurada.';
+    return;
+  }
+  header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login'));
+  exit;
+});
+
+$router->get('/admin/login', function () {
+  $slug = resolve_default_company_slug();
+  if (!$slug) {
+    http_response_code(404);
+    echo 'Empresa não configurada.';
+    return;
+  }
+  header('Location: ' . base_url('admin/' . rawurlencode($slug) . '/login'));
+  exit;
+});
+
 /* ========= Rotas públicas (cardápio) ========= */
 $router->get('/{slug}',                       'PublicHomeController@index');
 $router->get('/{slug}/buscar',                'PublicHomeController@buscar');


### PR DESCRIPTION
## Summary
- derive the public base URL from the current host/proxy headers and expose a webroot helper
- add support for resolving a default company slug in configuration, the model and auth redirect logic
- register fallback public/admin routes that render or redirect using the default company slug

## Testing
- php -l app/core/Helpers.php
- php -l app/models/Company.php
- php -l app/core/Auth.php
- php -l routes/web.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d0e8468cdc832eb929605ace7a852c