### PR TITLE
Use company header color for admin gradients

### DIFF
--- a/app/views/admin/categories/form.php
+++ b/app/views/admin/categories/form.php
@@ -15,12 +15,12 @@ ob_start(); ?>
 
 <!-- HEADER -->
 <header class="mb-6 flex items-center gap-3">
-  <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-emerald-500 text-white shadow">
+  <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl admin-gradient-bg text-white shadow">
     <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
       <path d="M6 6h12v12H6z" stroke="currentColor" stroke-width="1.6"/>
     </svg>
   </span>
-  <h1 class="bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-2xl font-semibold text-transparent">
+  <h1 class="admin-gradient-text bg-clip-text text-2xl font-semibold text-transparent">
     <?= $editing ? 'Editar' : 'Nova' ?> Categoria
   </h1>
 </header>
@@ -56,7 +56,7 @@ ob_start(); ?>
 
   <!-- Botões -->
   <div class="mt-2 flex gap-3">
-    <button class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+    <button class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
       <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none">
         <path d="M20 7 9 18l-5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>

--- a/app/views/admin/categories/index.php
+++ b/app/views/admin/categories/index.php
@@ -13,12 +13,12 @@ ob_start(); ?>
 
 <!-- HEADER -->
 <header class="mb-6 flex items-center gap-3">
-  <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-emerald-500 text-white shadow">
+  <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl admin-gradient-bg text-white shadow">
     <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
       <path d="M6 6h12v12H6z" stroke="currentColor" stroke-width="1.6"/>
     </svg>
   </span>
-  <h1 class="bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-2xl font-semibold text-transparent">
+  <h1 class="admin-gradient-text bg-clip-text text-2xl font-semibold text-transparent">
     Categorias
   </h1>
 
@@ -30,7 +30,7 @@ ob_start(); ?>
     </a>
 
     <a href="<?= e(base_url('admin/' . $slug . '/categories/create')) ?>"
-       class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-3 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+       class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-3 py-2 text-sm font-medium text-white shadow hover:opacity-95">
       <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
       Nova
     </a>
@@ -47,7 +47,7 @@ ob_start(); ?>
     <p class="mt-1 text-sm text-slate-500">Crie a primeira categoria para organizar seus produtos.</p>
     <div class="mt-4">
       <a href="<?= e(base_url('admin/' . $slug . '/categories/create')) ?>"
-         class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+         class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
         <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
         Criar categoria
       </a>

--- a/app/views/admin/dashboard/index.php
+++ b/app/views/admin/dashboard/index.php
@@ -33,7 +33,7 @@ $price = function($v){ return 'R$ ' . number_format((float)$v, 2, ',', '.'); };
 ob_start(); ?>
 
 <!-- HERO / TOPO -->
-<section class="relative mb-6 overflow-hidden rounded-3xl border border-slate-200 bg-gradient-to-br from-indigo-600 via-indigo-500 to-emerald-600">
+<section class="relative mb-6 overflow-hidden rounded-3xl border border-slate-200 admin-gradient-bg text-white">
   <div class="absolute -right-20 -top-20 h-64 w-64 rounded-full bg-white/10 blur-2xl"></div>
   <div class="absolute -bottom-16 -left-16 h-64 w-64 rounded-full bg-black/10 blur-3xl"></div>
 

--- a/app/views/admin/ingredients/form.php
+++ b/app/views/admin/ingredients/form.php
@@ -71,12 +71,12 @@ ob_start(); ?>
 <!-- HEADER -->
 <header class="mb-5 flex flex-wrap items-center gap-3">
   <div class="flex items-center gap-3">
-    <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-emerald-500 text-white shadow">
+    <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl admin-gradient-bg text-white shadow">
       <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
         <path d="M5 7h14M7 12h10M9 17h8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
       </svg>
     </span>
-    <h1 class="bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-2xl font-semibold text-transparent">
+    <h1 class="admin-gradient-text bg-clip-text text-2xl font-semibold text-transparent">
       <?= $editing ? 'Editar' : 'Novo' ?> ingrediente
     </h1>
   </div>

--- a/app/views/admin/ingredients/index.php
+++ b/app/views/admin/ingredients/index.php
@@ -27,12 +27,12 @@ ob_start(); ?>
 <!-- HEADER -->
 <header class="mb-5 flex flex-wrap items-center gap-3">
   <div class="flex items-center gap-3">
-    <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-emerald-500 text-white shadow">
+    <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl admin-gradient-bg text-white shadow">
       <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
         <path d="M4 7h16M7 12h10M10 17h7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
       </svg>
     </span>
-    <h1 class="bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-2xl font-semibold text-transparent">
+    <h1 class="admin-gradient-text bg-clip-text text-2xl font-semibold text-transparent">
       Ingredientes
     </h1>
   </div>
@@ -51,7 +51,7 @@ ob_start(); ?>
     </a>
 
     <a href="<?= e(base_url('admin/' . $slug . '/ingredients/create')) ?>"
-       class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-3 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+       class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-3 py-2 text-sm font-medium text-white shadow hover:opacity-95">
       <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
       Novo
     </a>
@@ -207,7 +207,7 @@ ob_start(); ?>
     <p class="mt-1 text-sm text-slate-500">Ajuste os filtros ou crie um novo ingrediente.</p>
     <div class="mt-4">
       <a href="<?= e(base_url('admin/' . $slug . '/ingredients/create')) ?>"
-         class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+         class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
         <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
         Criar ingrediente
       </a>

--- a/app/views/admin/layout.php
+++ b/app/views/admin/layout.php
@@ -1,10 +1,33 @@
 <!doctype html>
 <html lang="pt-br">
+<?php
+$companyData = is_array($company ?? null) ? $company : null;
+$adminPrimaryColor = admin_theme_primary_color($companyData);
+$adminPrimarySoft = hex_to_rgba($adminPrimaryColor, 0.55, $adminPrimaryColor);
+$adminPrimaryGradient = admin_theme_gradient($companyData);
+?>
 <head>
   <meta charset="utf-8">
   <title><?= e($title ?? 'Admin') ?></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      --admin-primary-color: <?= e($adminPrimaryColor) ?>;
+      --admin-primary-soft: <?= e($adminPrimarySoft) ?>;
+      --admin-primary-gradient: <?= e($adminPrimaryGradient) ?>;
+    }
+    .admin-gradient-bg {
+      background-image: var(--admin-primary-gradient);
+      background-color: var(--admin-primary-color);
+    }
+    .admin-gradient-text {
+      background-image: var(--admin-primary-gradient);
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+    }
+  </style>
 </head>
 <body class="bg-slate-50 text-slate-900">
   <div class="max-w-5xl mx-auto p-4">

--- a/app/views/admin/orders/form.php
+++ b/app/views/admin/orders/form.php
@@ -14,12 +14,12 @@ ob_start(); ?>
 
   <!-- HEADER -->
   <header class="mb-5 flex items-center gap-3">
-    <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-emerald-500 text-white shadow">
+    <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl admin-gradient-bg text-white shadow">
       <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
         <path d="M5 7h14M7 12h10M9 17h8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
       </svg>
     </span>
-    <h1 class="bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-2xl font-semibold text-transparent">
+    <h1 class="admin-gradient-text bg-clip-text text-2xl font-semibold text-transparent">
       Novo pedido
     </h1>
 
@@ -152,7 +152,7 @@ ob_start(); ?>
 
     <!-- AÇÕES -->
     <div class="flex gap-2">
-      <button class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+      <button class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
         <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none"><path d="M20 7 9 18l-5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         Salvar pedido
       </button>

--- a/app/views/admin/orders/index.php
+++ b/app/views/admin/orders/index.php
@@ -44,19 +44,19 @@ ob_start(); ?>
   <!-- HEADER -->
   <header class="mb-5 flex flex-wrap items-center gap-3">
     <div class="flex items-center gap-3">
-      <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-emerald-500 text-white shadow">
+      <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl admin-gradient-bg text-white shadow">
         <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
           <path d="M5 7h14M7 12h10M9 17h8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
         </svg>
       </span>
-      <h1 class="bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-2xl font-semibold text-transparent">
+      <h1 class="admin-gradient-text bg-clip-text text-2xl font-semibold text-transparent">
         Pedidos
       </h1>
     </div>
 
     <div class="ml-auto flex items-center gap-2">
       <a href="<?= e(base_url('admin/' . $slug . '/orders/create')) ?>"
-         class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-3 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+        class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-3 py-2 text-sm font-medium text-white shadow hover:opacity-95">
         <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
         Novo pedido
       </a>
@@ -114,7 +114,7 @@ ob_start(); ?>
       <p class="mt-1 text-sm text-slate-500">Ajuste os filtros ou crie um novo pedido agora mesmo.</p>
       <div class="mt-4">
         <a href="<?= e(base_url('admin/' . $slug . '/orders/create')) ?>"
-           class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+          class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
           <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
           Novo pedido
         </a>

--- a/app/views/admin/orders/show.php
+++ b/app/views/admin/orders/show.php
@@ -40,10 +40,10 @@ ob_start(); ?>
   <!-- HEADER -->
   <header class="mb-5 flex flex-wrap items-center gap-3">
     <div class="flex items-center gap-3">
-      <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-emerald-500 text-white shadow">
+      <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl admin-gradient-bg text-white shadow">
         <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none"><path d="M5 7h14M7 12h10M9 17h8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>
       </span>
-      <h1 class="bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-2xl font-semibold text-transparent">
+      <h1 class="admin-gradient-text bg-clip-text text-2xl font-semibold text-transparent">
         Pedido #<?= (int)($o['id'] ?? 0) ?>
       </h1>
       <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[12px] font-medium ring-1 <?= $badgeClass ?>">

--- a/app/views/admin/products/form.php
+++ b/app/views/admin/products/form.php
@@ -67,7 +67,7 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
           Cancelar
         </a>
         <button type="submit"
-                class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-4 py-1.5 text-sm font-medium text-white shadow hover:opacity-95">
+                class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-4 py-1.5 text-sm font-medium text-white shadow hover:opacity-95">
           <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none"><path d="M20 7 9 18l-5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           Salvar
         </button>

--- a/app/views/admin/products/index.php
+++ b/app/views/admin/products/index.php
@@ -22,12 +22,12 @@ ob_start(); ?>
 <!-- HEADER -->
 <header class="mb-5 flex flex-wrap items-center gap-3">
   <div class="flex items-center gap-3">
-    <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-emerald-500 text-white shadow">
+    <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl admin-gradient-bg text-white shadow">
       <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
         <path d="M4 7h16M7 12h10M10 17h7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
       </svg>
     </span>
-    <h1 class="bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-2xl font-semibold text-transparent">
+    <h1 class="admin-gradient-text bg-clip-text text-2xl font-semibold text-transparent">
       Produtos
     </h1>
   </div>
@@ -46,7 +46,7 @@ ob_start(); ?>
     </a>
 
     <a href="<?= e(base_url('admin/' . $slug . '/products/create')) ?>"
-       class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-3 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+       class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-3 py-2 text-sm font-medium text-white shadow hover:opacity-95">
       <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
       Novo
     </a>
@@ -140,7 +140,7 @@ if ($status !== '') {
     <p class="mt-1 text-sm text-slate-500">Ajuste os filtros ou crie um novo produto.</p>
     <div class="mt-4">
       <a href="<?= e(base_url('admin/' . $slug . '/products/create')) ?>"
-         class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+        class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
         <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
         Criar produto
       </a>

--- a/app/views/admin/settings/index.php
+++ b/app/views/admin/settings/index.php
@@ -47,12 +47,12 @@ ob_start(); ?>
 
 <!-- HEADER -->
 <header class="mb-6 flex items-center gap-3">
-  <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-emerald-500 text-white shadow">
+  <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl admin-gradient-bg text-white shadow">
     <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
       <path d="M4 7h16M7 12h10M10 17h7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
     </svg>
   </span>
-  <h1 class="bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-2xl font-semibold text-transparent">
+  <h1 class="admin-gradient-text bg-clip-text text-2xl font-semibold text-transparent">
     Configurações gerais
   </h1>
 
@@ -268,7 +268,7 @@ ob_start(); ?>
 
   <!-- AÇÕES -->
   <div class="flex gap-2">
-    <button class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
+    <button class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
       <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none"><path d="M20 7 9 18l-5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       Salvar
     </button>


### PR DESCRIPTION
## Summary
- add helper utilities that derive the admin primary color and gradient from company settings
- expose reusable gradient utility classes in the admin layout and apply them across dashboard and CRUD views so they match the configured palette

## Testing
- for f in app/core/Helpers.php app/views/admin/layout.php app/views/admin/dashboard/index.php app/views/admin/categories/index.php app/views/admin/categories/form.php app/views/admin/products/index.php app/views/admin/products/form.php app/views/admin/ingredients/index.php app/views/admin/ingredients/form.php app/views/admin/orders/index.php app/views/admin/orders/show.php app/views/admin/orders/form.php app/views/admin/settings/index.php; do php -l $f || break; done

------
https://chatgpt.com/codex/tasks/task_e_68d18f7990fc832e8c32623a665d8d35