### PR TITLE
Allow viewing inactive products in admin list

### DIFF
--- a/app/controllers/AdminProductController.php
+++ b/app/controllers/AdminProductController.php
@@ -74,7 +74,7 @@ class AdminProductController extends Controller {
     unset($_SESSION['flash_error']);
 
     $cats  = Category::allByCompany((int)$company['id']);
-    $items = Product::listByCompany((int)$company['id'], $_GET['q'] ?? null);
+    $items = Product::listByCompany((int)$company['id'], $_GET['q'] ?? null, false);
 
     return $this->view('admin/products/index', compact('company','cats','items','error'));
   }

--- a/app/models/Product.php
+++ b/app/models/Product.php
@@ -45,9 +45,12 @@ class Product
    * LISTAGENS / BÁSICO
    * ======================== */
 
-  public static function listByCompany(int $companyId, ?string $q = null): array {
-    $sql = "SELECT * FROM products WHERE company_id = ? AND active = 1";
+  public static function listByCompany(int $companyId, ?string $q = null, bool $onlyActive = true): array {
+    $sql = "SELECT * FROM products WHERE company_id = ?";
     $args = [$companyId];
+    if ($onlyActive) {
+      $sql .= " AND active = 1";
+    }
     if ($q) {
       $sql .= " AND (name LIKE ? OR description LIKE ?)";
       $args[] = "%$q%"; $args[] = "%$q%";


### PR DESCRIPTION
## Summary
- update the product repository method to optionally return inactive items
- load all products in the admin listing so the table can show inactive status badges

## Testing
- php -l app/models/Product.php
- php -l app/controllers/AdminProductController.php

------
https://chatgpt.com/codex/tasks/task_e_68d1ce05a7dc832e9af8e24216695a92