### PR TITLE
Integrate combo group management with customizable items

### DIFF
--- a/app/models/Product.php
+++ b/app/models/Product.php
@@ -81,6 +81,43 @@ class Product
     return $st->fetchAll(PDO::FETCH_ASSOC);
   }
 
+  /**
+   * Retorna produtos simples ativos da empresa, usados para montar combos.
+   */
+  public static function simpleProductsForCombo(int $companyId, ?int $excludeId = null): array {
+    $sql = "SELECT p.id,
+                   p.name,
+                   p.price,
+                   p.promo_price,
+                   p.allow_customize,
+                   COALESCE(c.ingredient_count,0) AS ingredient_count
+              FROM products p
+         LEFT JOIN (
+                SELECT pcg.product_id, COUNT(pci.id) AS ingredient_count
+                  FROM product_custom_groups pcg
+                  JOIN product_custom_items pci ON pci.group_id = pcg.id
+              GROUP BY pcg.product_id
+            ) c ON c.product_id = p.id
+             WHERE p.company_id = :cid
+               AND p.type = 'simple'
+               AND p.active = 1";
+
+    if ($excludeId) {
+      $sql .= " AND p.id <> :exclude";
+    }
+
+    $sql .= " ORDER BY p.name";
+
+    $st = db()->prepare($sql);
+    $st->bindValue(':cid', $companyId, PDO::PARAM_INT);
+    if ($excludeId) {
+      $st->bindValue(':exclude', $excludeId, PDO::PARAM_INT);
+    }
+    $st->execute();
+
+    return $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
+  }
+
   public static function find(int $id): ?array {
     $st = db()->prepare("SELECT * FROM products WHERE id = ?");
     $st->execute([$id]);
@@ -196,6 +233,120 @@ class Product
     ]);
   }
 
+  /**
+   * Normaliza grupos de combo vindos do formulário admin.
+   */
+  public static function normalizeComboGroups(array $groups, int $companyId): array {
+    if (!$groups) {
+      return [];
+    }
+
+    $allowed = [];
+    foreach (self::simpleProductsForCombo($companyId) as $sp) {
+      $allowed[(int)$sp['id']] = [
+        'allow_customize'  => !empty($sp['allow_customize']),
+        'ingredient_count' => (int)($sp['ingredient_count'] ?? 0),
+      ];
+    }
+
+    $normalized = [];
+    foreach ($groups as $index => $group) {
+      $name = trim((string)($group['name'] ?? ''));
+      if ($name === '') {
+        continue;
+      }
+
+      $itemsRaw = $group['items'] ?? [];
+      if (!is_array($itemsRaw) || !$itemsRaw) {
+        continue;
+      }
+
+      $min = isset($group['min']) ? max(0, (int)$group['min']) : 0;
+      $max = isset($group['max']) ? (int)$group['max'] : 1;
+      if ($max < $min) {
+        $max = $min;
+      }
+      if ($max <= 0) {
+        $max = 1;
+      }
+
+      $items = [];
+      foreach ($itemsRaw as $item) {
+        $productId = (int)($item['product_id'] ?? 0);
+        if ($productId <= 0 || !isset($allowed[$productId])) {
+          continue;
+        }
+
+        $delta = isset($item['delta']) ? (float)$item['delta'] : 0.0;
+        $isDefault = !empty($item['default']) ? 1 : 0;
+
+        $eligible = $allowed[$productId]['allow_customize'] && $allowed[$productId]['ingredient_count'] >= 3;
+        $customizable = $eligible && !empty($item['customizable']) ? 1 : 0;
+
+        $items[] = [
+          'product_id'   => $productId,
+          'delta'        => $delta,
+          'default'      => $isDefault,
+          'customizable' => $customizable,
+        ];
+      }
+
+      if (!$items) {
+        continue;
+      }
+
+      $normalized[] = [
+        'name'       => $name,
+        'type'       => $max > 1 ? 'addon' : 'single',
+        'min'        => $min,
+        'max'        => $max,
+        'sort_order' => isset($group['sort_order']) ? (int)$group['sort_order'] : (int)$index,
+        'items'      => $items,
+      ];
+    }
+
+    usort($normalized, static function ($a, $b) {
+      return ($a['sort_order'] ?? 0) <=> ($b['sort_order'] ?? 0);
+    });
+
+    return $normalized;
+  }
+
+  /**
+   * Ajusta os grupos salvos para o formato usado pelo formulário admin.
+   */
+  public static function loadComboGroupsForAdmin(int $productId): array {
+    $raw = self::getComboGroupsWithItems($productId);
+    if (!$raw) {
+      return [];
+    }
+
+    $result = [];
+    foreach ($raw as $group) {
+      $items = [];
+      foreach (($group['items'] ?? []) as $item) {
+        $items[] = [
+          'product_id'   => (int)($item['simple_id'] ?? $item['product_id'] ?? 0),
+          'delta'        => isset($item['delta']) ? (float)$item['delta'] : 0.0,
+          'default'      => !empty($item['is_default'] ?? $item['default']),
+          'customizable' => !empty($item['is_customizable'] ?? $item['customizable']),
+        ];
+      }
+
+      $result[] = [
+        'id'         => (int)($group['id'] ?? 0),
+        'name'       => $group['name'] ?? '',
+        'type'       => $group['type'] ?? 'single',
+        'min'        => (int)($group['min'] ?? 0),
+        'max'        => (int)($group['max'] ?? 1),
+        'sort_order' => (int)($group['sort'] ?? 0),
+        'items'      => $items,
+      ];
+    }
+
+    return $result;
+  }
+
   public static function delete(int $id): void {
     // Se preferir soft delete, troque por update de deleted_at.
     $st = db()->prepare("DELETE FROM products WHERE id=?");
@@ -281,18 +432,34 @@ class Product
              gi.simple_product_id AS simple_id,
              COALESCE(gi.delta_price,0) AS delta,
              COALESCE(gi.is_default,0)  AS is_default,
+             COALESCE(gi.is_customizable,0) AS is_customizable,
              sp.name,
              sp.image,
-             sp.price AS base_price
+             sp.price AS base_price,
+             sp.allow_customize,
+             COALESCE(c.ingredient_count,0) AS ingredient_count
         FROM combo_group_items gi
   INNER JOIN products sp ON sp.id = gi.simple_product_id
+   LEFT JOIN (
+          SELECT pcg.product_id, COUNT(pci.id) AS ingredient_count
+            FROM product_custom_groups pcg
+            JOIN product_custom_items pci ON pci.group_id = pcg.id
+        GROUP BY pcg.product_id
+        ) c ON c.product_id = sp.id
        WHERE gi.group_id = ?
     ORDER BY gi.sort ASC, gi.id ASC
     ");
 
     foreach ($groups as &$g) {
       $iq->execute([$g['id']]);
-      $g['items'] = $iq->fetchAll(PDO::FETCH_ASSOC) ?: [];
+      $items = $iq->fetchAll(PDO::FETCH_ASSOC) ?: [];
+      foreach ($items as &$item) {
+        $item['default'] = !empty($item['is_default']) ? 1 : 0;
+        $item['customizable'] = !empty($item['is_customizable']) ? 1 : 0;
+        $item['id'] = isset($item['simple_id']) ? (int)$item['simple_id'] : (int)($item['id'] ?? 0);
+      }
+      unset($item);
+      $g['items'] = $items;
     }
     unset($g);
 
@@ -329,8 +496,8 @@ class Product
           VALUES (?,?,?,?,?,?,NOW())
         ");
         $insI = $pdo->prepare("
-          INSERT INTO combo_group_items (group_id, simple_product_id, delta_price, is_default, sort, created_at)
-          VALUES (?,?,?,?,?,NOW())
+          INSERT INTO combo_group_items (group_id, simple_product_id, delta_price, is_default, is_customizable, sort, created_at)
+          VALUES (?,?,?,?,?,?,NOW())
         ");
 
         $gSort = 0;
@@ -352,7 +519,8 @@ class Product
             if ($spId <= 0) continue;
             $delta  = (float)($it['delta'] ?? 0);
             $isDef  = !empty($it['default']) ? 1 : 0;
-            $insI->execute([$groupId, $spId, $delta, $isDef, $iSort++]);
+            $isCust = !empty($it['customizable']) ? 1 : 0;
+            $insI->execute([$groupId, $spId, $delta, $isDef, $isCust, $iSort++]);
           }
         }
       }

--- a/app/views/admin/products/form.php
+++ b/app/views/admin/products/form.php
@@ -268,6 +268,12 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
     #groups-container .group-card{transition:transform .18s ease,box-shadow .18s ease,opacity .18s ease}
     #groups-container .group-card.dragging{opacity:.85;transform:scale(.985);box-shadow:0 18px 35px -20px rgba(15,23,42,.45)}
     .combo-drag-ghost{box-sizing:border-box;border-radius:.75rem;box-shadow:0 18px 35px -20px rgba(15,23,42,.45)}
+    .combo-customizable-btn{display:inline-flex;align-items:center;gap:.4rem;border:1px solid #cbd5f5;border-radius:.75rem;padding:.45rem .75rem;font-size:.875rem;background:#fff;color:#475569;transition:background-color .15s ease,border-color .15s ease,color .15s ease}
+    .combo-customizable-btn:hover{background:#f8fafc}
+    .combo-customizable-btn.is-active{border-color:#6366f1;background:#eef2ff;color:#3730a3}
+    .combo-customizable-btn.hidden{display:none!important}
+    .combo-customizable-hint{color:#64748b}
+    .combo-customizable-hint.hidden{display:none!important}
   </style>
 
   <!-- CARD: Grupos (Combo) -->
@@ -321,7 +327,7 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
             $selId = (int)($it['product_id'] ?? 0);
             $isDef = !empty($it['is_default'] ?? $it['default']);
           ?>
-          <div class="item-row grid grid-cols-1 gap-3 p-3 md:grid-cols-[minmax(0,1fr)_160px_72px_72px_auto_40px] md:items-center" data-item-index="<?= $ii ?>">
+          <div class="item-row grid grid-cols-1 gap-3 p-3 md:grid-cols-[minmax(0,1fr)_160px_72px_72px_auto_minmax(0,1fr)_40px] md:items-center" data-item-index="<?= $ii ?>">
             <div>
               <label class="block text-xs text-slate-500">Produto</label>
               <select name="groups[<?= $gi ?>][items][<?= $ii ?>][product_id]"
@@ -329,7 +335,11 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
                       title="Selecione um item da lista." required>
                 <option value="">— Selecione um produto simples —</option>
                 <?php foreach ($simpleProducts as $sp): ?>
-                  <option value="<?= (int)$sp['id'] ?>" data-price="<?= e((string)($sp['price'] ?? '0')) ?>" <?= $selId === (int)$sp['id'] ? 'selected' : '' ?>>
+                  <option value="<?= (int)$sp['id'] ?>"
+                          data-price="<?= e((string)($sp['price'] ?? '0')) ?>"
+                          data-allow-customize="<?= !empty($sp['allow_customize']) ? '1' : '0' ?>"
+                          data-ingredients="<?= (int)($sp['ingredient_count'] ?? 0) ?>"
+                          <?= $selId === (int)$sp['id'] ? 'selected' : '' ?>>
                     <?= e($sp['name']) ?><?= isset($sp['price']) ? ' — R$ ' . number_format((float)$sp['price'], 2, ',', '.') : '' ?>
                   </option>
                 <?php endforeach; ?>
@@ -349,21 +359,34 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
             </div>
             <label class="inline-flex items-center gap-2 text-sm text-slate-700">
               <input type="checkbox" name="groups[<?= $gi ?>][items][<?= $ii ?>][default]" value="1" <?= $isDef ? 'checked' : '' ?> class="h-4 w-4 rounded border-slate-300 text-indigo-600">
-              <span>Default</span>
+              <span>Acompanhamento padrão</span>
             </label>
+            <div class="combo-customizable flex flex-col items-start gap-1 text-sm">
+              <input type="hidden" class="combo-customizable-flag" name="groups[<?= $gi ?>][items][<?= $ii ?>][customizable]" value="<?= $isCustItem ? '1' : '0' ?>">
+              <button type="button"
+                      class="combo-customizable-btn<?= $isCustItem ? ' is-active' : '' ?>"
+                      data-active="<?= $isCustItem ? '1' : '0' ?>"
+                      aria-pressed="<?= $isCustItem ? 'true' : 'false' ?>">
+                Produto personalizável
+              </button>
+              <small class="combo-customizable-hint text-xs text-slate-500 hidden">Disponível para itens com personalização ativa.</small>
+            </div>
             <div class="flex justify-end">
               <button type="button" class="remove-item shrink-0 rounded-full p-2 text-slate-400 hover:text-red-600" aria-label="Remover item">✕</button>
             </div>
             <input type="hidden" name="groups[<?= $gi ?>][items][<?= $ii ?>][delta]" value="0">
           </div>
           <?php endforeach; else: ?>
-          <div class="item-row grid grid-cols-1 gap-3 p-3 md:grid-cols-[minmax(0,1fr)_160px_72px_72px_auto_40px] md:items-center" data-item-index="0">
+          <div class="item-row grid grid-cols-1 gap-3 p-3 md:grid-cols-[minmax(0,1fr)_160px_72px_72px_auto_minmax(0,1fr)_40px] md:items-center" data-item-index="0">
             <div>
               <label class="block text-xs text-slate-500">Produto</label>
               <select name="groups[<?= $gi ?>][items][0][product_id]" class="product-select w-full rounded-lg border border-slate-300 bg-white px-3 py-2" title="Selecione um item da lista." required>
                 <option value="">— Selecione um produto simples —</option>
                 <?php foreach ($simpleProducts as $sp): ?>
-                  <option value="<?= (int)$sp['id'] ?>" data-price="<?= e((string)($sp['price'] ?? '0')) ?>">
+                  <option value="<?= (int)$sp['id'] ?>"
+                          data-price="<?= e((string)($sp['price'] ?? '0')) ?>"
+                          data-allow-customize="<?= !empty($sp['allow_customize']) ? '1' : '0' ?>"
+                          data-ingredients="<?= (int)($sp['ingredient_count'] ?? 0) ?>">
                     <?= e($sp['name']) ?><?= isset($sp['price']) ? ' — R$ ' . number_format((float)$sp['price'], 2, ',', '.') : '' ?>
                   </option>
                 <?php endforeach; ?>
@@ -383,8 +406,18 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
             </div>
             <label class="inline-flex items-center gap-2 text-sm text-slate-700">
               <input type="checkbox" name="groups[<?= $gi ?>][items][0][default]" value="1" class="h-4 w-4 rounded border-slate-300 text-indigo-600">
-              <span>Default</span>
+              <span>Acompanhamento padrão</span>
             </label>
+            <div class="combo-customizable flex flex-col items-start gap-1 text-sm">
+              <input type="hidden" class="combo-customizable-flag" name="groups[<?= $gi ?>][items][0][customizable]" value="0">
+              <button type="button"
+                      class="combo-customizable-btn"
+                      data-active="0"
+                      aria-pressed="false">
+                Produto personalizável
+              </button>
+              <small class="combo-customizable-hint text-xs text-slate-500 hidden">Disponível para itens com personalização ativa.</small>
+            </div>
             <div class="flex justify-end">
               <button type="button" class="remove-item shrink-0 rounded-full p-2 text-slate-400 hover:text-red-600" aria-label="Remover item">✕</button>
             </div>
@@ -657,13 +690,16 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
         <button type="button" class="remove-group shrink-0 rounded-full p-2 text-slate-400 hover:text-red-600" aria-label="Remover grupo">✕</button>
       </div>
 
-      <div class="item-row grid grid-cols-1 gap-3 p-3 md:grid-cols-[minmax(0,1fr)_160px_72px_72px_auto_40px] md:items-center" data-item-index="0">
+      <div class="item-row grid grid-cols-1 gap-3 p-3 md:grid-cols-[minmax(0,1fr)_160px_72px_72px_auto_minmax(0,1fr)_40px] md:items-center" data-item-index="0">
         <div>
           <label class="block text-xs text-slate-500">Produto</label>
           <select name="groups[__GI__][items][0][product_id]" class="product-select w-full rounded-lg border border-slate-300 bg-white px-3 py-2" title="Selecione um item da lista." required>
             <option value="">— Selecione um produto simples —</option>
             <?php foreach ($simpleProducts as $sp): ?>
-              <option value="<?= (int)$sp['id'] ?>" data-price="<?= e((string)($sp['price'] ?? '0')) ?>">
+              <option value="<?= (int)$sp['id'] ?>"
+                      data-price="<?= e((string)($sp['price'] ?? '0')) ?>"
+                      data-allow-customize="<?= !empty($sp['allow_customize']) ? '1' : '0' ?>"
+                      data-ingredients="<?= (int)($sp['ingredient_count'] ?? 0) ?>">
                 <?= e($sp['name']) ?><?= isset($sp['price']) ? ' — R$ ' . number_format((float)$sp['price'], 2, ',', '.') : '' ?>
               </option>
             <?php endforeach; ?>
@@ -687,8 +723,18 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
 
         <label class="inline-flex items-center gap-2 text-sm text-slate-700">
           <input type="checkbox" class="h-4 w-4 rounded border-slate-300 text-indigo-600" name="groups[__GI__][items][0][default]" value="1">
-          <span>Default</span>
+          <span>Acompanhamento padrão</span>
         </label>
+        <div class="combo-customizable flex flex-col items-start gap-1 text-sm">
+          <input type="hidden" class="combo-customizable-flag" name="groups[__GI__][items][0][customizable]" value="0">
+          <button type="button"
+                  class="combo-customizable-btn"
+                  data-active="0"
+                  aria-pressed="false">
+            Produto personalizável
+          </button>
+          <small class="combo-customizable-hint text-xs text-slate-500 hidden">Disponível para itens com personalização ativa.</small>
+        </div>
 
         <div class="flex justify-end">
           <button type="button" class="remove-item shrink-0 rounded-full p-2 text-slate-400 hover:text-red-600" aria-label="Remover item">✕</button>
@@ -705,13 +751,16 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
   </template>
 
   <template id="tpl-item">
-    <div class="item-row grid grid-cols-1 gap-3 p-3 md:grid-cols-[minmax(0,1fr)_160px_72px_72px_auto_40px] md:items-center" data-item-index="__II__">
+    <div class="item-row grid grid-cols-1 gap-3 p-3 md:grid-cols-[minmax(0,1fr)_160px_72px_72px_auto_minmax(0,1fr)_40px] md:items-center" data-item-index="__II__">
       <div>
         <label class="block text-xs text-slate-500">Produto</label>
         <select name="groups[__GI__][items][__II__][product_id]" class="product-select w-full rounded-lg border border-slate-300 bg-white px-3 py-2" title="Selecione um item da lista." required>
           <option value="">— Selecione um produto simples —</option>
           <?php foreach ($simpleProducts as $sp): ?>
-            <option value="<?= (int)$sp['id'] ?>" data-price="<?= e((string)($sp['price'] ?? '0')) ?>">
+            <option value="<?= (int)$sp['id'] ?>"
+                    data-price="<?= e((string)($sp['price'] ?? '0')) ?>"
+                    data-allow-customize="<?= !empty($sp['allow_customize']) ? '1' : '0' ?>"
+                    data-ingredients="<?= (int)($sp['ingredient_count'] ?? 0) ?>">
               <?= e($sp['name']) ?><?= isset($sp['price']) ? ' — R$ ' . number_format((float)$sp['price'], 2, ',', '.') : '' ?>
             </option>
           <?php endforeach; ?>
@@ -735,8 +784,18 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
 
       <label class="inline-flex items-center gap-2 text-sm text-slate-700">
         <input type="checkbox" class="h-4 w-4 rounded border-slate-300 text-indigo-600" name="groups[__GI__][items][__II__][default]" value="1">
-        <span>Default</span>
+        <span>Acompanhamento padrão</span>
       </label>
+      <div class="combo-customizable flex flex-col items-start gap-1 text-sm">
+        <input type="hidden" class="combo-customizable-flag" name="groups[__GI__][items][__II__][customizable]" value="0">
+        <button type="button"
+                class="combo-customizable-btn"
+                data-active="0"
+                aria-pressed="false">
+          Produto personalizável
+        </button>
+        <small class="combo-customizable-hint text-xs text-slate-500 hidden">Disponível para itens com personalização ativa.</small>
+      </div>
 
       <div class="flex justify-end">
         <button type="button" class="remove-item shrink-0 rounded-full p-2 text-slate-400 hover:text-red-600" aria-label="Remover item">✕</button>
@@ -916,11 +975,71 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
       const footer=groupEl.querySelector('.group-base-price');
       if(footer) footer.textContent=`Preço base: ${formatMoney(sum)}`;
     }
+    function updateCustomizableControls(row){
+      const sel=row.querySelector('.product-select');
+      const btn=row.querySelector('.combo-customizable-btn');
+      const flag=row.querySelector('.combo-customizable-flag');
+      const hint=row.querySelector('.combo-customizable-hint');
+      if(!btn || !flag){ return; }
+      const opt=sel?.selectedOptions?.[0];
+      const allow=opt?.dataset?.allowCustomize==='1';
+      const count=Number(opt?.dataset?.ingredients ?? '0');
+      const eligible=allow && count>=3;
+      if(!eligible){
+        btn.classList.add('hidden');
+        btn.classList.remove('is-active');
+        btn.setAttribute('aria-pressed','false');
+        btn.dataset.active='0';
+        flag.value='0';
+        hint?.classList.add('hidden');
+        return;
+      }
+      btn.classList.remove('hidden');
+      hint?.classList.remove('hidden');
+      const active = flag.value==='1' || btn.dataset.active==='1';
+      if(active){
+        btn.classList.add('is-active');
+        btn.setAttribute('aria-pressed','true');
+        flag.value='1';
+        btn.dataset.active='1';
+      }else{
+        btn.classList.remove('is-active');
+        btn.setAttribute('aria-pressed','false');
+        flag.value='0';
+        btn.dataset.active='0';
+      }
+    }
     function wireItemRow(row){
       const sel=row.querySelector('.product-select');
       const def=row.querySelector('input[type=checkbox][name*="[default]"]');
-      if(sel){ sel.addEventListener('change',()=>{ updateItemPrice(row); updateGroupFooter(row.closest('.group-card')); }); updateItemPrice(row); }
+      const btn=row.querySelector('.combo-customizable-btn');
+      const flag=row.querySelector('.combo-customizable-flag');
+      if(sel){
+        sel.addEventListener('change',()=>{
+          updateItemPrice(row);
+          updateGroupFooter(row.closest('.group-card'));
+          if(flag){ flag.value='0'; }
+          if(btn){
+            btn.classList.remove('is-active');
+            btn.setAttribute('aria-pressed','false');
+            btn.dataset.active='0';
+          }
+          updateCustomizableControls(row);
+        });
+        updateItemPrice(row);
+      }
       if(def){ def.addEventListener('change',()=>updateGroupFooter(row.closest('.group-card'))); }
+      if(btn && flag){
+        btn.addEventListener('click',()=>{
+          if(btn.classList.contains('hidden')) return;
+          const nowActive = !btn.classList.contains('is-active');
+          btn.classList.toggle('is-active', nowActive);
+          btn.setAttribute('aria-pressed', nowActive ? 'true' : 'false');
+          flag.value = nowActive ? '1' : '0';
+          btn.dataset.active = nowActive ? '1' : '0';
+        });
+      }
+      updateCustomizableControls(row);
     }
     document.querySelectorAll('.group-card').forEach(g=>{ g.querySelectorAll('.item-row').forEach(wireItemRow); updateGroupFooter(g); });
 

--- a/app/views/public/product.php
+++ b/app/views/public/product.php
@@ -145,6 +145,8 @@ if (!function_exists('local_upload_src')) {
   .choice.sel .mark{display:grid}
   .choice-name{margin-top:10px;font-weight:700;font-size:15px;color:#1f2937}
   .choice-price{margin-top:4px;color:#374151;font-size:14px}
+  .choice-customize{margin-top:8px;display:inline-flex;align-items:center;justify-content:center;width:100%;padding:6px 10px;border-radius:12px;border:1px solid #d1d5db;background:#fff;color:#1f2937;font-size:13px;font-weight:600;cursor:pointer;transition:background-color .15s ease}
+  .choice-customize:hover{background:#f3f4f6}
 
   /* ===== FOOTER/CTA ===== */
   .footer{position:sticky;bottom:0;background:var(--card);padding:12px 16px 18px;border-top:1px solid var(--border);box-shadow:0 -10px 40px rgba(0,0,0,.06)}
@@ -274,11 +276,14 @@ if (!function_exists('local_upload_src')) {
               $isDefault = !empty($opt['default']);
               $optPrice = (isset($opt['delta']) ? (float)$opt['delta'] : 0.0);
               $priceLabel = $optPrice != 0.0 ? price_br($optPrice) : 'Incluído';
+              $customizable = !empty($opt['customizable']) && !empty($opt['allow_customize']) && (int)($opt['ingredient_count'] ?? 0) >= 3;
+              $customSimpleId = (int)($opt['id'] ?? 0);
+              $customUrl = ($customizable && $customSimpleId > 0) ? base_url($slug . '/produto/' . $customSimpleId . '/customizar') : null;
 
               // Força imagem do item do combo vir de /uploads
               $comboImg = local_upload_src($opt['image'] ?? null);
             ?>
-            <div class="choice <?= $isDefault ? 'sel' : '' ?>" data-group="<?= (int)$gi ?>" data-id="<?= (int)($opt['id'] ?? 0) ?>">
+            <div class="choice <?= $isDefault ? 'sel' : '' ?>" data-group="<?= (int)$gi ?>" data-id="<?= $customSimpleId ?>">
               <button type="button" class="ring" aria-pressed="<?= $isDefault ? 'true':'false' ?>">
                <img src="<?= e($comboImg) ?>" alt="<?= e($opt['name'] ?? '') ?>">
                 <span class="mark" aria-hidden="true">
@@ -287,6 +292,9 @@ if (!function_exists('local_upload_src')) {
               </button>
               <div class="choice-name"><?= e($opt['name'] ?? '') ?></div>
               <div class="choice-price"><?= e($priceLabel) ?></div>
+              <?php if ($customizable && $customUrl): ?>
+                <button type="button" class="choice-customize" data-url="<?= e($customUrl) ?>">Personalizar</button>
+              <?php endif; ?>
             </div>
           <?php endforeach; ?>
         </div>
@@ -353,6 +361,13 @@ if (!function_exists('local_upload_src')) {
         ring.setAttribute('aria-pressed','true');
         if (hidden) hidden.value = item.dataset.id || '';
       });
+    });
+  });
+  document.querySelectorAll('.choice-customize').forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      const url = btn.dataset.url;
+      if(!url) return;
+      window.open(url, '_blank', 'noopener');
     });
   });
 </script>

--- a/database/menu_schema_with_customization.sql
+++ b/database/menu_schema_with_customization.sql
@@ -199,6 +199,7 @@ CREATE TABLE `combo_group_items` (
   `simple_product_id` int(11) NOT NULL,
   `delta_price` decimal(10,2) DEFAULT 0.00,
   `is_default` tinyint(1) DEFAULT 0,
+  `is_customizable` tinyint(1) DEFAULT 0,
   `sort` int(11) DEFAULT 0,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL


### PR DESCRIPTION
## Summary
* load simple products with customization metadata for combo builders and normalize/sync combo group payloads when saving
* wire admin product controller to persist combo type, pricing mode, and combo groups while providing the form with eligible simple products
* enhance the admin combo UI with customizable toggles, data attributes, and scripting, and surface combo customization entry points on the public product page
* add database support for marking combo items as customizable

## Testing
* php -l app/models/Product.php
* php -l app/controllers/AdminProductController.php
* php -l app/views/admin/products/form.php
* php -l app/views/public/product.php

------
https://chatgpt.com/codex/tasks/task_e_68d3206bd658832ea51d6a6878862e57