### PR TITLE
Implement combo group customization workflow

### DIFF
--- a/database/menu_schema_with_customization.sql
+++ b/database/menu_schema_with_customization.sql
@@ -199,6 +199,7 @@ CREATE TABLE `combo_group_items` (
   `simple_product_id` int(11) NOT NULL,
   `delta_price` decimal(10,2) DEFAULT 0.00,
   `is_default` tinyint(1) DEFAULT 0,
+  `allow_customize` tinyint(1) NOT NULL DEFAULT 0,
   `sort` int(11) DEFAULT 0,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL


### PR DESCRIPTION
## Summary
- load and persist combo groups using only simple products and enforce customizable rules
- update the admin combo group UI to manage default accompaniment and customizable flags per item
- expose combo selections with optional customization on the public product view and document the new schema column

## Testing
- php -l app/models/Product.php
- php -l app/controllers/AdminProductController.php
- php -l app/views/admin/products/form.php
- php -l app/views/public/product.php

------
https://chatgpt.com/codex/tasks/task_e_68d355e1e194832eb8113e100b87535b