### PR TITLE
Fix combo item selection persistence

### DIFF
--- a/app/models/Product.php
+++ b/app/models/Product.php
@@ -297,6 +297,10 @@ class Product
       foreach ($rows as &$row) {
         $row['default'] = !empty($row['is_default']);
         $row['customizable'] = !empty($row['allow_customize']);
+
+        if (!isset($row['product_id'])) {
+          $row['product_id'] = isset($row['simple_id']) ? (int)$row['simple_id'] : null;
+        }
       }
       unset($row);
       $g['items'] = $rows;

--- a/app/views/admin/products/form.php
+++ b/app/views/admin/products/form.php
@@ -329,7 +329,7 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
 
           <?php if (!empty($gItems)): foreach ($gItems as $ii => $it):
             $ii    = (int)$ii;
-            $selId = (int)($it['product_id'] ?? 0);
+            $selId = (int)($it['product_id'] ?? $it['simple_id'] ?? $it['simple_product_id'] ?? 0);
             $isDef = !empty($it['is_default'] ?? $it['default']);
           ?>
           <?php
@@ -380,7 +380,7 @@ if (!function_exists('e')) { function e($s){ return htmlspecialchars((string)$s,
             <div class="flex justify-end">
               <button type="button" class="remove-item shrink-0 rounded-full p-2 text-slate-400 hover:text-red-600" aria-label="Remover item">✕</button>
             </div>
-            <input type="hidden" name="groups[<?= $gi ?>][items][<?= $ii ?>][delta]" value="0">
+            <input type="hidden" name="groups[<?= $gi ?>][items][<?= $ii ?>][delta]" value="<?= e($it['delta'] ?? $it['delta_price'] ?? 0) ?>">
           </div>
           <?php endforeach; else: ?>
           <div class="item-row grid grid-cols-1 gap-3 p-3 md:grid-cols-[minmax(0,1fr)_160px_72px_72px_minmax(0,180px)_40px] md:items-center" data-item-index="0">


### PR DESCRIPTION
## Summary
- ensure combo group items retrieved for admin forms expose product_id aliases
- preselect existing simple products and keep stored delta values when editing groups

## Testing
- php -l app/models/Product.php
- php -l app/views/admin/products/form.php

------
https://chatgpt.com/codex/tasks/task_e_68d374392928832ea98c3ba8e47b6e3a