### PR TITLE
Handle Homebrew bundle option compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ brew:
 	echo 'Instalando Homebrew...'; \
 	/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; \
 	fi; \
-	brew bundle --no-lock; \
+	if brew bundle --help 2>&1 | grep -q -- "--no-lock"; then \
+		brew bundle --no-lock; \
+	else \
+		brew bundle; \
+	fi; \
 	else \
 	echo 'Homebrew não é necessário neste sistema. Pulando etapa.'; \
 	fi


### PR DESCRIPTION
## Summary
- update the Homebrew setup step to detect whether the `--no-lock` flag is supported before using it
- fall back to a plain `brew bundle` run when the option is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4cf4f7dc8832eb577d99633fce593