### PR TITLE
Update demo slug to wollburger

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ O alvo `setup` cuida das seguintes etapas:
 
 Após o `make setup` a aplicação estará disponível em [http://localhost:8000](http://localhost:8000).
 
+- O cardápio de demonstração pode ser acessado diretamente em [`http://localhost:8000/wollburger`](http://localhost:8000/wollburger).
+
 O stack também sobe um phpMyAdmin em [http://localhost:8081](http://localhost:8081) (configure `FORWARD_PHPMYADMIN_PORT` para alterar a porta) já apontando para o container MySQL.
 
 > **Observação:** em máquinas sem Docker Desktop o `make setup` tentará iniciar o Colima automaticamente. Caso nenhum engine esteja ativo, o comando instruirá a iniciar o serviço manualmente.

--- a/database/seeds/001_default_company.sql
+++ b/database/seeds/001_default_company.sql
@@ -24,8 +24,8 @@ INSERT INTO companies (
   created_at
 ) VALUES (
   1,
-  'demo-burger',
-  'Demo Burger',
+  'wollburger',
+  'WollBurger',
   '11999998888',
   'Av. Central, 123, São Paulo - SP',
   'Peça os clássicos da casa!',


### PR DESCRIPTION
## Summary
- rename the seeded demo company to use the wollburger slug and name
- document the demo cardápio URL in the README for quick access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d60bb88e80832e9e3f3daac6eed3f2