### PR TITLE
Align ingredients foreign key and add database task wrapper

### DIFF
--- a/database/migrations/20230927_align_ingredients_company_fk.sql
+++ b/database/migrations/20230927_align_ingredients_company_fk.sql
@@ -1,0 +1,27 @@
+-- Ensure ingredients.company_id matches companies.id for FK compatibility
+SET @fk_name := (
+  SELECT CONSTRAINT_NAME
+  FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'ingredients'
+    AND COLUMN_NAME = 'company_id'
+    AND REFERENCED_TABLE_NAME = 'companies'
+  LIMIT 1
+);
+
+SET @sql := IF(
+  @fk_name IS NOT NULL,
+  CONCAT('ALTER TABLE `ingredients` DROP FOREIGN KEY `', @fk_name, '`'),
+  'SET @dummy = 0'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+ALTER TABLE `ingredients`
+  MODIFY `company_id` INT UNSIGNED NOT NULL;
+
+ALTER TABLE `ingredients`
+  ADD CONSTRAINT `fk_ingredients_company`
+    FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`) ON DELETE CASCADE;

--- a/scripts/db_task.sh
+++ b/scripts/db_task.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Uso: $0 <migrate|seed>" >&2
+  exit 1
+fi
+
+TASK="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$TASK" in
+  migrate|seed)
+    "${SCRIPT_DIR}/run_app_task.sh" "$TASK"
+    ;;
+  *)
+    echo "Tarefa desconhecida: $TASK" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add a db_task helper script so the Makefile migrate/seed targets invoke the existing container task runner
- add a SQL migration that normalizes ingredients.company_id and recreates the foreign key to match companies.id

## Testing
- make migrate *(fails: Docker CLI não encontrado neste ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68d612d1074c832e96f9b7f7f78d069c