### PR TITLE
Handle docker compose failures in run_app_task

### DIFF
--- a/scripts/run_app_task.sh
+++ b/scripts/run_app_task.sh
@@ -17,11 +17,19 @@ if [[ ! -x "${DOCKER_COMPOSE_SCRIPT}" ]]; then
 fi
 
 run_in_existing_container() {
+  set +e
   "${DOCKER_COMPOSE_SCRIPT}" exec -T app "$@"
+  local status=$?
+  set -e
+  return ${status}
 }
 
 run_in_temporary_container() {
+  set +e
   "${DOCKER_COMPOSE_SCRIPT}" run --rm --no-deps app "$@"
+  local status=$?
+  set -e
+  return ${status}
 }
 
 primary_cmd=()


### PR DESCRIPTION
## Summary
- wrap run_app_task docker helpers with temporary set +e blocks so failures return control
- capture and propagate docker command exit statuses to allow fallback handling

## Testing
- scripts/run_app_task.sh migrate

------
https://chatgpt.com/codex/tasks/task_e_68d6195588b4832e8cec4e984268a20e