### PR TITLE
Fix base URL handling behind proxies

### DIFF
--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -22,42 +22,267 @@ if (!function_exists('config')) {
 if (!function_exists('base_url')) {
     function base_url(string $path = ''): string
     {
-        $base = (string) config('app.url');
+        $parseHostPort = static function (?string $value): array {
+            $value = trim((string) ($value ?? ''));
 
-        if ($base !== '') {
-            $hostHeader = $_SERVER['HTTP_HOST'] ?? '';
+            if ($value === '') {
+                return ['', null];
+            }
 
-            if ($hostHeader !== '') {
-                $parsed = parse_url($base);
+            $value = trim($value, " \t\n\r\0\x0B\"'");
 
-                if ($parsed !== false && isset($parsed['host'])) {
-                    $headerHost = $hostHeader;
-                    $headerPort = null;
+            if ($value === '') {
+                return ['', null];
+            }
 
-                    if (str_contains($hostHeader, ':')) {
-                        [$headerHost, $headerPort] = explode(':', $hostHeader, 2);
+            $value = explode(',', $value, 2)[0];
+            $value = trim($value);
+
+            if ($value === '') {
+                return ['', null];
+            }
+
+            if (strncmp($value, '//', 2) !== 0) {
+                $value = '//' . ltrim($value, '/');
+            }
+
+            $parsed = parse_url($value);
+
+            if ($parsed === false) {
+                return ['', null];
+            }
+
+            $host = $parsed['host'] ?? '';
+
+            if ($host === '' && isset($parsed['path'])) {
+                $host = $parsed['path'];
+            }
+
+            $port = isset($parsed['port']) ? (int) $parsed['port'] : null;
+
+            return [$host, $port];
+        };
+
+        $formatHost = static function (string $host): string {
+            $host = trim($host);
+
+            if ($host === '') {
+                return '';
+            }
+
+            if (strncmp($host, '[', 1) === 0 && substr($host, -1) === ']') {
+                return $host;
+            }
+
+            if (str_contains($host, ':')) {
+                return '[' . trim($host, '[]') . ']';
+            }
+
+            return $host;
+        };
+
+        $formatPort = static function (?int $port, string $scheme): string {
+            if ($port === null) {
+                return '';
+            }
+
+            $normalizedScheme = strtolower($scheme);
+
+            if (($normalizedScheme === 'http' && $port === 80)
+                || ($normalizedScheme === 'https' && $port === 443)) {
+                return '';
+            }
+
+            return ':' . $port;
+        };
+
+        $detectedScheme = 'http';
+        $detectedHost = '';
+        $detectedPort = null;
+
+        if (!empty($_SERVER['HTTP_FORWARDED'])) {
+            $forwardedValues = explode(',', (string) $_SERVER['HTTP_FORWARDED']);
+            $firstForwarded = trim($forwardedValues[0]);
+
+            if ($firstForwarded !== '') {
+                $pairs = preg_split('/;\s*/', $firstForwarded);
+
+                foreach ($pairs as $pair) {
+                    if ($pair === null || $pair === '') {
+                        continue;
                     }
 
-                    if ($headerPort !== null
-                        && !isset($parsed['port'])
-                        && strcasecmp($parsed['host'], $headerHost) === 0) {
-                        $scheme = $parsed['scheme'] ?? 'http';
-                        $user = $parsed['user'] ?? '';
-                        $pass = $parsed['pass'] ?? '';
-                        $auth = $user !== '' ? $user . ($pass !== '' ? ':' . $pass : '') . '@' : '';
-                        $basePath = $parsed['path'] ?? '';
+                    $kv = explode('=', $pair, 2);
 
-                        $base = sprintf('%s://%s%s%s', $scheme, $auth, $hostHeader, $basePath);
+                    if (count($kv) !== 2) {
+                        continue;
+                    }
+
+                    $key = strtolower(trim($kv[0]));
+                    $value = trim($kv[1], " \t\n\r\0\x0B\"'");
+
+                    if ($value === '') {
+                        continue;
+                    }
+
+                    if ($key === 'proto') {
+                        $detectedScheme = strtolower($value);
+                    } elseif ($key === 'host') {
+                        [$forwardHost, $forwardPort] = $parseHostPort($value);
+
+                        if ($forwardHost !== '') {
+                            $detectedHost = $forwardHost;
+                        }
+
+                        if ($forwardPort !== null) {
+                            $detectedPort = $forwardPort;
+                        }
                     }
                 }
             }
         }
 
-        if ($base === '') {
-            $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
-            $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
-            $dir    = rtrim((string) dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/');
-            $base   = $scheme . '://' . $host . ($dir ? $dir : '');
+        if ($detectedHost === '' && !empty($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+            [$candidateHost, $candidatePort] = $parseHostPort((string) $_SERVER['HTTP_X_FORWARDED_HOST']);
+
+            if ($candidateHost !== '') {
+                $detectedHost = $candidateHost;
+
+                if ($detectedPort === null && $candidatePort !== null) {
+                    $detectedPort = $candidatePort;
+                }
+            }
+        }
+
+        if ($detectedHost === '' && !empty($_SERVER['HTTP_HOST'])) {
+            [$candidateHost, $candidatePort] = $parseHostPort((string) $_SERVER['HTTP_HOST']);
+
+            if ($candidateHost !== '') {
+                $detectedHost = $candidateHost;
+
+                if ($detectedPort === null && $candidatePort !== null) {
+                    $detectedPort = $candidatePort;
+                }
+            }
+        }
+
+        if ($detectedHost === '' && !empty($_SERVER['SERVER_NAME'])) {
+            $detectedHost = (string) $_SERVER['SERVER_NAME'];
+        }
+
+        if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+            $candidate = trim((string) $_SERVER['HTTP_X_FORWARDED_PROTO']);
+
+            if ($candidate !== '') {
+                $detectedScheme = strtolower(explode(',', $candidate, 2)[0]);
+            }
+        } elseif (!empty($_SERVER['HTTP_X_FORWARDED_SCHEME'])) {
+            $candidate = trim((string) $_SERVER['HTTP_X_FORWARDED_SCHEME']);
+
+            if ($candidate !== '') {
+                $detectedScheme = strtolower(explode(',', $candidate, 2)[0]);
+            }
+        } elseif (!empty($_SERVER['REQUEST_SCHEME'])) {
+            $detectedScheme = strtolower((string) $_SERVER['REQUEST_SCHEME']);
+        } elseif (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+            $detectedScheme = 'https';
+        }
+
+        if ($detectedPort === null && !empty($_SERVER['HTTP_X_FORWARDED_PORT'])) {
+            $detectedPort = (int) $_SERVER['HTTP_X_FORWARDED_PORT'];
+        }
+
+        if ($detectedPort === null && !empty($_SERVER['SERVER_PORT'])) {
+            $detectedPort = (int) $_SERVER['SERVER_PORT'];
+        }
+
+        $configUrl = (string) config('app.url');
+        $parsedConfig = $configUrl !== '' ? parse_url($configUrl) : false;
+
+        $scheme = $detectedScheme ?: 'http';
+        $host = $detectedHost;
+        $port = $detectedPort;
+        $auth = '';
+        $basePath = '';
+
+        if ($parsedConfig !== false) {
+            if (!empty($parsedConfig['scheme'])) {
+                $scheme = $parsedConfig['scheme'];
+            }
+
+            if (!empty($parsedConfig['host'])) {
+                $host = $parsedConfig['host'];
+            }
+
+            if (isset($parsedConfig['port'])) {
+                $port = (int) $parsedConfig['port'];
+            } elseif (!empty($parsedConfig['host'])
+                && $detectedHost !== ''
+                && strcasecmp($parsedConfig['host'], $detectedHost) === 0
+                && $detectedPort !== null) {
+                $port = $detectedPort;
+            }
+
+            if (!empty($parsedConfig['user'])) {
+                $auth = $parsedConfig['user'];
+
+                if (!empty($parsedConfig['pass'])) {
+                    $auth .= ':' . $parsedConfig['pass'];
+                }
+
+                $auth .= '@';
+            }
+
+            if (isset($parsedConfig['path'])) {
+                $basePath = (string) $parsedConfig['path'];
+            }
+        } else {
+            if ($configUrl !== '') {
+                $basePath = $configUrl;
+            }
+        }
+
+        if ($host === '') {
+            $host = $detectedHost !== '' ? $detectedHost : 'localhost';
+
+            if ($port === null && $detectedPort !== null) {
+                $port = $detectedPort;
+            }
+        }
+
+        if ($basePath === '') {
+            $dir = rtrim((string) dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/');
+
+            if ($dir === '.') {
+                $dir = '';
+            }
+
+            if ($configUrl === '' && $dir !== '') {
+                $basePath = $dir;
+            }
+        }
+
+        $basePath = trim($basePath);
+
+        if ($basePath !== '') {
+            $basePath = '/' . ltrim($basePath, '/');
+            $basePath = rtrim($basePath, '/');
+        }
+
+        $scheme = $scheme !== '' ? strtolower($scheme) : 'http';
+
+        $formattedHost = $formatHost($host);
+
+        if ($formattedHost === '') {
+            $formattedHost = 'localhost';
+        }
+
+        $portSegment = $formatPort($port, $scheme);
+
+        $base = sprintf('%s://%s%s%s', $scheme, $auth, $formattedHost, $portSegment);
+
+        if ($basePath !== '') {
+            $base .= $basePath;
         }
 
         $base = rtrim($base, '/');

--- a/config/app.php
+++ b/config/app.php
@@ -6,7 +6,7 @@ return [
     'name' => env('APP_NAME', 'Multi Menu'),
     'env' => env('APP_ENV', 'production'),
     'debug' => (bool) env('APP_DEBUG', true),
-    'url' => env('APP_URL', 'http://localhost'),
+    'url' => env('APP_URL', 'http://localhost:8000'),
     'timezone' => env('APP_TIMEZONE', 'America/Sao_Paulo'),
     'session_name' => env('SESSION_NAME', 'mm_session'),
     'novidades_days' => (int) env('APP_NEWS_DAYS', 0),

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -14,6 +14,9 @@ server {
         fastcgi_pass app:9000;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTP_HOST $http_host;
+        fastcgi_param HTTP_X_FORWARDED_HOST $http_host;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
         fastcgi_buffers 16 16k;
         fastcgi_buffer_size 32k;
     }


### PR DESCRIPTION
## Summary
- expand the `base_url` helper to honor forwarded hosts, protocols, and ports so generated links stay on the requested origin
- default the application URL to `http://localhost:8000` to align with the documented development endpoint
- propagate host and protocol headers from Nginx to PHP so port-aware URLs work inside the container

## Testing
- php -l app/Support/helpers.php
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d62ec508cc832e8e0cd0a4d001a2f3