### PR TITLE
Fix admin dashboard company context helpers

### DIFF
--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -32,4 +32,30 @@ abstract class Controller
     {
         return Database::connection();
     }
+
+    /**
+     * Garante que o contexto de empresa ativo em sessão siga o acesso atual.
+     *
+     * Mantém sincronizado o ID e, se informado, o slug da empresa ativa.
+     */
+    protected function ensureCompanyContext(int $companyId, ?string $slug = null): void
+    {
+        $currentId = Auth::activeCompanyId();
+        $currentSlug = Auth::activeCompanySlug();
+
+        $shouldUpdateId = $currentId !== $companyId;
+        $shouldUpdateSlug = $slug !== null && $slug !== '' && $currentSlug !== $slug;
+
+        if ($shouldUpdateId || $shouldUpdateSlug) {
+            Auth::setActiveCompany($companyId, $slug);
+        }
+    }
+
+    /**
+     * Retorna o slug atualmente ativo no contexto da empresa logada.
+     */
+    protected function currentCompanySlug(): ?string
+    {
+        return Auth::activeCompanySlug();
+    }
 }


### PR DESCRIPTION
## Summary
- add reusable helper methods on the base controller to manage the active company context
- ensure slugs stay synchronized in session to prevent dashboard access errors

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d6e461d344832e98d2403dcbcd2e0c