### PR TITLE
Fix admin dashboard context helpers

### DIFF
--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -33,6 +33,16 @@ class AdminDashboardController extends Controller
         $this->ingredients = new IngredientService();
     }
 
+    private function ensureCompanyContext(int $companyId, string $slug): void
+    {
+        Auth::setActiveCompany($companyId, $slug);
+    }
+
+    private function currentCompanySlug(): ?string
+    {
+        return Auth::activeCompanySlug();
+    }
+
     /**
    * Garante autenticação e contexto de empresa pelo slug.
    * Retorna [ $user, $company ].


### PR DESCRIPTION
## Summary
- ensure the dashboard controller stores the active company context through the Auth helper
- expose a helper to read the active company slug when rendering dashboard links

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e461d344832e98d2403dcbcd2e0c