### PR TITLE
Fix admin dashboard visibility error

### DIFF
--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -33,16 +33,6 @@ class AdminDashboardController extends Controller
         $this->ingredients = new IngredientService();
     }
 
-    private function ensureCompanyContext(int $companyId, string $slug): void
-    {
-        Auth::setActiveCompany($companyId, $slug);
-    }
-
-    private function currentCompanySlug(): ?string
-    {
-        return Auth::activeCompanySlug();
-    }
-
     /**
    * Garante autenticação e contexto de empresa pelo slug.
    * Retorna [ $user, $company ].


### PR DESCRIPTION
## Summary
- remove the private overrides of `ensureCompanyContext` and `currentCompanySlug` in `AdminDashboardController`
- rely on the protected helpers from the base controller to avoid PHP visibility fatals when dispatching the dashboard route

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d6ea25d350832e95e171d6677a67d9