### PR TITLE
Fix admin dashboard visibility error

### DIFF
--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -33,16 +33,6 @@ class AdminDashboardController extends Controller
         $this->ingredients = new IngredientService();
     }
 
-    private function ensureCompanyContext(int $companyId, string $slug): void
-    {
-        Auth::setActiveCompany($companyId, $slug);
-    }
-
-    private function currentCompanySlug(): ?string
-    {
-        return Auth::activeCompanySlug();
-    }
-
     /**
    * Garante autenticação e contexto de empresa pelo slug.
    * Retorna [ $user, $company ].

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,25 +6,6 @@ declare(strict_types=1);
 $router->get('/admin/hash', 'AdminHashController@show');
 $router->post('/admin/hash', 'AdminHashController@generate');
 
-/* ========= Rotas públicas (cardápio) ========= */
-$router->get('/{slug}', 'PublicHomeController@index');
-$router->get('/{slug}/buscar', 'PublicHomeController@buscar');
-$router->get('/{slug}/produto/{id}', 'PublicProductController@show');
-$router->get('/{slug}/product/{id}', 'PublicProductController@show');
-
-/* Personalização de produto */
-$router->get('/{slug}/produto/{id}/customizar', 'PublicProductController@customize');
-$router->post('/{slug}/produto/{id}/customizar', 'PublicProductController@saveCustomization');
-
-/* Carrinho */
-$router->get('/{slug}/cart', 'PublicCartController@index');
-$router->post('/{slug}/cart/add', 'PublicCartController@add');
-
-/* ========= Rotas cliente ========= */
-$router->post('/{slug}/customer-login', 'CustomerAuthController@login');
-$router->post('/{slug}/customer-logout', 'CustomerAuthController@logout');
-$router->get('/{slug}/customer-me', 'CustomerAuthController@me');
-
 /* ========= Rotas admin ========= */
 $router->get('/admin/{slug}/login', 'AdminAuthController@loginForm');
 $router->post('/admin/{slug}/login', 'AdminAuthController@login');
@@ -69,3 +50,22 @@ $router->post('/admin/{slug}/delivery-fees/zones/{id}', 'AdminDeliveryFeeControl
 $router->post('/admin/{slug}/delivery-fees/zones/{id}/delete', 'AdminDeliveryFeeController@destroyZone');
 $router->post('/admin/{slug}/delivery-fees/zones-adjust', 'AdminDeliveryFeeController@adjustZones');
 $router->post('/admin/{slug}/delivery-fees/options', 'AdminDeliveryFeeController@updateOptions');
+
+/* ========= Rotas públicas (cardápio) ========= */
+$router->get('/{slug}', 'PublicHomeController@index');
+$router->get('/{slug}/buscar', 'PublicHomeController@buscar');
+$router->get('/{slug}/produto/{id}', 'PublicProductController@show');
+$router->get('/{slug}/product/{id}', 'PublicProductController@show');
+
+/* Personalização de produto */
+$router->get('/{slug}/produto/{id}/customizar', 'PublicProductController@customize');
+$router->post('/{slug}/produto/{id}/customizar', 'PublicProductController@saveCustomization');
+
+/* Carrinho */
+$router->get('/{slug}/cart', 'PublicCartController@index');
+$router->post('/{slug}/cart/add', 'PublicCartController@add');
+
+/* ========= Rotas cliente ========= */
+$router->post('/{slug}/customer-login', 'CustomerAuthController@login');
+$router->post('/{slug}/customer-logout', 'CustomerAuthController@logout');
+$router->get('/{slug}/customer-me', 'CustomerAuthController@me');


### PR DESCRIPTION
## Summary
- remove the private overrides of `ensureCompanyContext` and `currentCompanySlug` in `AdminDashboardController`
- rely on the protected helpers from the base controller to avoid PHP visibility fatals when dispatching the dashboard route
- move the `/admin/{slug}` route definitions ahead of the public slug catch-all so admin URLs resolve correctly

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d6ea25d350832e95e171d6677a67d9