### PR TITLE
Fix test tooling configuration and eliminate deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor/
 /.env
 /.phpunit.result.cache
+/.phpunit.cache/
 /.php-cs-fixer.cache
 /var/cache/*
 !/var/cache/.gitignore

--- a/app/Support/Config.php
+++ b/app/Support/Config.php
@@ -52,6 +52,24 @@ final class Config
         self::$items = $items;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    public static function all(): array
+    {
+        self::ensureLoaded();
+
+        return self::$items ?? [];
+    }
+
+    /**
+     * @param array<string, mixed>|null $items
+     */
+    public static function replace(?array $items): void
+    {
+        self::$items = $items;
+    }
+
     public static function get(string $key, mixed $default = null): mixed
     {
         self::ensureLoaded();

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
       "phpstan analyse --memory-limit=512M"
     ],
     "test": [
-      "phpunit"
+      "@php vendor/bin/phpunit"
     ],
     "quality": [
       "@lint",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="tests/bootstrap.php"
-         colors="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="Application">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">app</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" beStrictAboutOutputDuringTests="true" beStrictAboutTestsThatDoNotTestAnything="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Application">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">app</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/Support/BaseUrlHelperTest.php
+++ b/tests/Support/BaseUrlHelperTest.php
@@ -9,7 +9,6 @@ use App\Support\Config;
 use function base_url;
 
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 
 final class BaseUrlHelperTest extends TestCase
 {
@@ -111,12 +110,7 @@ final class BaseUrlHelperTest extends TestCase
      */
     private function getConfigItems(): array
     {
-        $configRef = new ReflectionClass(Config::class);
-        $itemsProp = $configRef->getProperty('items');
-        $itemsProp->setAccessible(true);
-        $items = $itemsProp->getValue();
-
-        return is_array($items) ? $items : [];
+        return Config::all();
     }
 
     /**
@@ -124,9 +118,6 @@ final class BaseUrlHelperTest extends TestCase
      */
     private function setConfigItems(array $items): void
     {
-        $configRef = new ReflectionClass(Config::class);
-        $itemsProp = $configRef->getProperty('items');
-        $itemsProp->setAccessible(true);
-        $itemsProp->setValue($items);
+        Config::replace($items);
     }
 }


### PR DESCRIPTION
## Summary
- ensure the Composer test script uses the project-local PHPUnit binary and migrate the PHPUnit configuration to the current schema
- expose helper methods on the Config facade so tests can manage configuration without relying on deprecated reflection APIs
- ignore PHPUnit cache artifacts generated by the new configuration

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d6ef424818832e8c05da7d322139a1