### PR TITLE
Improve payment method metadata handling

### DIFF
--- a/app/models/PaymentMethod.php
+++ b/app/models/PaymentMethod.php
@@ -59,7 +59,7 @@ class PaymentMethod
             'INSERT INTO payment_methods (company_id, name, instructions, sort_order, active, `type`, `meta`, pix_key)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
         );
-        $meta = isset($data['meta']) ? json_encode($data['meta'], JSON_UNESCAPED_UNICODE) : null;
+        $meta = !empty($data['meta']) ? json_encode($data['meta'], JSON_UNESCAPED_UNICODE) : null;
         $st->execute([
             (int)$data['company_id'],
             $data['name'],
@@ -76,12 +76,12 @@ class PaymentMethod
 
     public static function update(int $id, int $companyId, array $data): void
     {
-                $st = db()->prepare(
-                        'UPDATE payment_methods
-                                SET name = ?, instructions = ?, sort_order = ?, active = ?, `type` = ?, `meta` = ?, pix_key = ?
-                            WHERE id = ? AND company_id = ?'
-                );
-        $meta = isset($data['meta']) ? json_encode($data['meta'], JSON_UNESCAPED_UNICODE) : null;
+        $st = db()->prepare(
+            'UPDATE payment_methods
+                SET name = ?, instructions = ?, sort_order = ?, active = ?, `type` = ?, `meta` = ?, pix_key = ?
+              WHERE id = ? AND company_id = ?'
+        );
+        $meta = !empty($data['meta']) ? json_encode($data['meta'], JSON_UNESCAPED_UNICODE) : null;
         $st->execute([
             $data['name'],
             $data['instructions'] ?? null,


### PR DESCRIPTION
## Summary
- normalise and validate payment method metadata, including Pix key fallback and canonical naming
- return decoded metadata for AJAX responses and only persist non-empty Pix credentials
- improve the admin form UX by restoring previous values, pre-filling Pix fields and fixing the Pix toggle initialisation

## Testing
- php -l app/controllers/AdminPaymentMethodController.php
- php -l app/models/PaymentMethod.php
- php -l app/views/admin/payments/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e2f196b684832eb7b3fde831042fe3