### PR TITLE
Improve Pix payment management UX

### DIFF
--- a/app/controllers/AdminPaymentMethodController.php
+++ b/app/controllers/AdminPaymentMethodController.php
@@ -10,6 +10,53 @@ require_once __DIR__ . '/../models/PaymentMethod.php';
 
 class AdminPaymentMethodController extends Controller
 {
+    private function detectPixKeyType(string $key): string
+    {
+        $key = trim($key);
+        if ($key === '') {
+            return '';
+        }
+
+        if (filter_var($key, FILTER_VALIDATE_EMAIL)) {
+            return 'email';
+        }
+
+        $digits = preg_replace('/\D+/', '', $key);
+        if (strlen($digits) === 11) {
+            return 'cpf';
+        }
+
+        if (strlen($digits) === 14) {
+            return 'cnpj';
+        }
+
+        if (strlen($digits) >= 10 && strlen($digits) <= 13) {
+            return 'telefone';
+        }
+
+        return 'aleatoria';
+    }
+
+    private function normaliseMeta($rawMeta): array
+    {
+        $meta = [];
+
+        if (is_array($rawMeta)) {
+            foreach ($rawMeta as $key => $value) {
+                if (!is_string($key)) {
+                    continue;
+                }
+                $value = trim((string)$value);
+                if ($value === '') {
+                    continue;
+                }
+                $meta[$key] = $value;
+            }
+        }
+
+        return $meta;
+    }
+
     private function guard(string $slug): array
     {
         Auth::start();
@@ -62,7 +109,14 @@ class AdminPaymentMethodController extends Controller
         $methods = PaymentMethod::allByCompany((int)$company['id']);
 
         $flash = $_SESSION['flash_payment'] ?? null;
-        $old   = $_SESSION['old_payment'] ?? ['name' => '', 'instructions' => '', 'sort_order' => PaymentMethod::nextSortOrder((int)$company['id']), 'active' => 1];
+        $old   = $_SESSION['old_payment'] ?? [
+            'name' => '',
+            'instructions' => '',
+            'sort_order' => PaymentMethod::nextSortOrder((int)$company['id']),
+            'active' => 1,
+            'type' => 'credit',
+            'meta' => [],
+        ];
         $errors = $_SESSION['errors_payment'] ?? [];
 
         unset($_SESSION['flash_payment'], $_SESSION['old_payment'], $_SESSION['errors_payment']);
@@ -93,10 +147,17 @@ class AdminPaymentMethodController extends Controller
             ? (int)$_POST['sort_order']
             : PaymentMethod::nextSortOrder((int)$company['id']);
         $active = isset($_POST['active']) ? 1 : 0;
+
+        $allowedTypes = ['credit', 'debit', 'others', 'voucher', 'pix'];
         $type = trim($_POST['type'] ?? 'others');
-        $meta = [];
-        if (!empty($_POST['meta']) && is_array($_POST['meta'])) {
-            $meta = $_POST['meta'];
+        if (!in_array($type, $allowedTypes, true)) {
+            $type = 'others';
+        }
+
+        $meta = $this->normaliseMeta($_POST['meta'] ?? []);
+
+        if ($type === 'pix' && $name === '') {
+            $name = 'Pix';
         }
 
         if ($name === '') {
@@ -106,15 +167,40 @@ class AdminPaymentMethodController extends Controller
                 'instructions' => $instructions,
                 'sort_order' => $sortOrder,
                 'active' => $active,
+                'type' => $type,
+                'meta' => $meta,
             ]);
             $this->flash(['type' => 'error', 'message' => 'Não foi possível salvar o método.']);
             $this->redirectToIndex($company['slug']);
         }
 
         // map pix_key: if type is pix, accept explicit pix_key or fall back to name field
-        $pixKey = trim($_POST['pix_key'] ?? '');
-        if ($type === 'pix' && $pixKey === '') {
-            $pixKey = $name; // user typed the key into the name field when label changed
+        $pixKey = '';
+        if ($type === 'pix') {
+            $pixKey = trim($meta['px_key'] ?? '');
+            if ($pixKey === '') {
+                $pixKey = trim($_POST['pix_key'] ?? '');
+            }
+            if ($pixKey === '') {
+                $nameFallback = trim($name);
+                if ($nameFallback !== '' && strcasecmp($nameFallback, 'Pix') !== 0) {
+                    $pixKey = $nameFallback;
+                }
+            }
+            if ($pixKey !== '') {
+                $meta['px_key'] = $pixKey;
+                $meta['px_key_type'] = $this->detectPixKeyType($pixKey);
+            } else {
+                unset($meta['px_key'], $meta['px_key_type']);
+            }
+            $pixHolder = trim($meta['px_holder_name'] ?? ($_POST['pix_holder_name'] ?? ''));
+            if ($pixHolder !== '') {
+                $meta['px_holder_name'] = $pixHolder;
+            }
+        }
+
+        if ($type !== 'pix') {
+            unset($meta['px_key'], $meta['px_provider'], $meta['px_holder_name'], $meta['px_key_type']);
         }
 
         // for records of type 'pix' store a canonical name
@@ -133,6 +219,10 @@ class AdminPaymentMethodController extends Controller
 
         // Load the created record
         $created = PaymentMethod::findForCompany((int)$newId, (int)$company['id']);
+        if ($created && isset($created['meta']) && is_string($created['meta'])) {
+            $decodedMeta = json_decode($created['meta'], true);
+            $created['meta'] = is_array($decodedMeta) ? $decodedMeta : [];
+        }
 
         if ($this->isAjaxRequest()) {
             header('Content-Type: application/json');
@@ -161,23 +251,74 @@ class AdminPaymentMethodController extends Controller
             ? (int)$_POST['sort_order']
             : (int)$method['sort_order'];
         $active = isset($_POST['active']) ? 1 : 0;
+        $allowedTypes = ['credit', 'debit', 'others', 'voucher', 'pix'];
         $type = trim($_POST['type'] ?? ($method['type'] ?? 'others'));
-        $meta = [];
-        if (!empty($_POST['meta']) && is_array($_POST['meta'])) {
-            $meta = $_POST['meta'];
-        } elseif (!empty($method['meta'])) {
-            $meta = json_decode((string)$method['meta'], true) ?: [];
+        if (!in_array($type, $allowedTypes, true)) {
+            $type = 'others';
         }
 
-        if ($name === '') {
+        $existingMeta = [];
+        if (!empty($method['meta'])) {
+            $decodedMeta = json_decode((string)$method['meta'], true);
+            if (is_array($decodedMeta)) {
+                $existingMeta = $this->normaliseMeta($decodedMeta);
+            }
+        }
+
+        $meta = $this->normaliseMeta($_POST['meta'] ?? []);
+        if (!$meta && $existingMeta) {
+            $meta = $existingMeta;
+        }
+
+        $isAjax = $this->isAjaxRequest();
+        $hasName = $name !== '';
+
+        if ($type === 'pix' && $name === '') {
+            $name = 'Pix';
+            $hasName = true;
+        }
+
+        if (!$hasName && !$isAjax) {
             $this->flash(['type' => 'error', 'message' => 'Informe o nome do método.']);
             $this->redirectToIndex($company['slug']);
         }
 
+        if ($isAjax && !$hasName && empty($_POST['meta']) && !isset($_POST['type']) && !isset($_POST['instructions'])) {
+            // toggle-only update: preserve existing fields
+            $name = (string)$method['name'];
+            $instructions = (string)($method['instructions'] ?? '');
+            $sortOrder = (int)$method['sort_order'];
+            $type = (string)($method['type'] ?? 'others');
+            $meta = $existingMeta;
+        }
+
         // map pix_key for update
-        $pixKey = trim($_POST['pix_key'] ?? '');
-        if ($type === 'pix' && $pixKey === '') {
-            $pixKey = $name; // user may have typed the key into name field
+        $pixKey = '';
+        if ($type === 'pix') {
+            $pixKey = trim($meta['px_key'] ?? '');
+            if ($pixKey === '') {
+                $pixKey = trim($_POST['pix_key'] ?? '');
+            }
+            if ($pixKey === '') {
+                $nameFallback = trim($name);
+                if ($nameFallback !== '' && strcasecmp($nameFallback, 'Pix') !== 0) {
+                    $pixKey = $nameFallback;
+                }
+            }
+            if ($pixKey !== '') {
+                $meta['px_key'] = $pixKey;
+                $meta['px_key_type'] = $this->detectPixKeyType($pixKey);
+            } else {
+                unset($meta['px_key'], $meta['px_key_type']);
+            }
+            $pixHolder = trim($meta['px_holder_name'] ?? ($_POST['pix_holder_name'] ?? ''));
+            if ($pixHolder !== '') {
+                $meta['px_holder_name'] = $pixHolder;
+            }
+        }
+
+        if ($type !== 'pix') {
+            unset($meta['px_key'], $meta['px_provider'], $meta['px_holder_name'], $meta['px_key_type']);
         }
 
         $saveName = $type === 'pix' ? 'Pix' : $name;
@@ -193,8 +334,12 @@ class AdminPaymentMethodController extends Controller
         ]);
 
         $updated = PaymentMethod::findForCompany($id, (int)$company['id']);
+        if ($updated && isset($updated['meta']) && is_string($updated['meta'])) {
+            $decodedMeta = json_decode($updated['meta'], true);
+            $updated['meta'] = is_array($decodedMeta) ? $decodedMeta : [];
+        }
 
-        if ($this->isAjaxRequest()) {
+        if ($isAjax) {
             header('Content-Type: application/json');
             echo json_encode(['success' => true, 'method' => $updated]);
             exit;

--- a/app/models/PaymentMethod.php
+++ b/app/models/PaymentMethod.php
@@ -59,7 +59,7 @@ class PaymentMethod
             'INSERT INTO payment_methods (company_id, name, instructions, sort_order, active, `type`, `meta`, pix_key)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
         );
-        $meta = isset($data['meta']) ? json_encode($data['meta'], JSON_UNESCAPED_UNICODE) : null;
+        $meta = !empty($data['meta']) ? json_encode($data['meta'], JSON_UNESCAPED_UNICODE) : null;
         $st->execute([
             (int)$data['company_id'],
             $data['name'],
@@ -76,12 +76,12 @@ class PaymentMethod
 
     public static function update(int $id, int $companyId, array $data): void
     {
-                $st = db()->prepare(
-                        'UPDATE payment_methods
-                                SET name = ?, instructions = ?, sort_order = ?, active = ?, `type` = ?, `meta` = ?, pix_key = ?
-                            WHERE id = ? AND company_id = ?'
-                );
-        $meta = isset($data['meta']) ? json_encode($data['meta'], JSON_UNESCAPED_UNICODE) : null;
+        $st = db()->prepare(
+            'UPDATE payment_methods
+                SET name = ?, instructions = ?, sort_order = ?, active = ?, `type` = ?, `meta` = ?, pix_key = ?
+              WHERE id = ? AND company_id = ?'
+        );
+        $meta = !empty($data['meta']) ? json_encode($data['meta'], JSON_UNESCAPED_UNICODE) : null;
         $st->execute([
             $data['name'],
             $data['instructions'] ?? null,

--- a/app/views/admin/payments/index.php
+++ b/app/views/admin/payments/index.php
@@ -6,12 +6,115 @@ if (!function_exists('e')) {
     }
 }
 
+if (!function_exists('render_payment_method_row')) {
+    function render_payment_method_row(array $method, array $pixTypeLabels, string $base)
+    {
+        $method = is_array($method) ? $method : [];
+        $methodId = (int)($method['id'] ?? 0);
+        $type = $method['type'] ?? 'others';
+        $meta = is_array($method['meta'] ?? null) ? $method['meta'] : [];
+        $isActive = !empty($method['active']);
+        $methodJson = htmlspecialchars(json_encode($method, JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
+        $trackClass = $isActive ? 'bg-rose-500' : 'bg-slate-200';
+        $thumbTransform = $isActive ? 'translateX(20px)' : 'translateX(0)';
+        $typeBadgeClass = $type === 'pix' ? 'bg-emerald-100 text-emerald-700' : ($type === 'credit' ? 'bg-rose-100 text-rose-700' : 'bg-slate-100 text-slate-700');
+        $typeLabel = ucfirst($type);
+
+        ob_start();
+        ?>
+        <div class="pm-row flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50 px-4 py-3" data-id="<?= $methodId ?>" data-type="<?= e($type) ?>" data-method="<?= $methodJson ?>">
+          <div class="flex items-center gap-3">
+            <div class="w-8 h-8 rounded-md bg-white flex items-center justify-center border border-slate-200">
+              <svg class="h-4 w-4 text-slate-500" viewBox="0 0 24 24" fill="none"><path d="M3 7h18M7 11h10M5 15h14" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+            <div>
+              <div class="flex items-center gap-2">
+                <div class="font-semibold text-slate-800"><?= e($method['name'] ?? '') ?></div>
+                <div class="text-xs rounded-full px-2 py-1 <?= $typeBadgeClass ?>"><?= e($typeLabel) ?></div>
+              </div>
+              <?php if ($type === 'pix'): ?>
+                <?php if (!empty($meta['px_key'])): ?><div class="text-xs text-slate-500">Chave Pix: <?= e($meta['px_key']) ?></div><?php endif; ?>
+                <?php if (!empty($meta['px_key_type'])): ?><div class="text-xs text-slate-500">Tipo da chave: <?= e($pixTypeLabels[$meta['px_key_type']] ?? ucfirst($meta['px_key_type'])) ?></div><?php endif; ?>
+                <?php if (!empty($meta['px_holder_name'])): ?><div class="text-xs text-slate-500">Titular: <?= e($meta['px_holder_name']) ?></div><?php endif; ?>
+              <?php endif; ?>
+              <div class="text-xs text-slate-500">ID #<?= $methodId ?></div>
+            </div>
+          </div>
+          <div class="flex items-center gap-3">
+            <label class="inline-flex items-center cursor-pointer">
+              <input data-id="<?= $methodId ?>" type="checkbox" class="pm-toggle sr-only" <?= $isActive ? 'checked' : '' ?> />
+              <span class="pm-toggle-track w-10 h-6 <?= $trackClass ?> rounded-full relative transition-colors">
+                <span class="pm-toggle-thumb absolute left-0.5 top-0.5 w-5 h-5 bg-white rounded-full shadow transform transition-transform" style="transform: <?= $thumbTransform ?>"></span>
+              </span>
+            </label>
+            <button type="button" class="pm-edit text-sm text-slate-500" data-id="<?= $methodId ?>">Editar</button>
+          </div>
+        </div>
+        <?php
+        return trim((string)ob_get_clean());
+    }
+}
+
 $company = is_array($company ?? null) ? $company : [];
 $methods = is_array($methods ?? null) ? $methods : [];
 $flash   = is_array($flash ?? null) ? $flash : null;
-$old     = is_array($old ?? null) ? $old : ['name' => '', 'instructions' => '', 'sort_order' => 0, 'active' => 1];
+$old     = is_array($old ?? null) ? $old : ['name' => '', 'instructions' => '', 'sort_order' => 0, 'active' => 1, 'type' => 'credit', 'meta' => []];
 $errors  = is_array($errors ?? null) ? $errors : [];
 $user    = $user ?? null;
+
+$old['meta'] = is_array($old['meta'] ?? null) ? $old['meta'] : [];
+$oldType = is_string($old['type'] ?? null) ? $old['type'] : 'credit';
+$allowedTypes = ['credit', 'debit', 'others', 'voucher', 'pix'];
+if (!in_array($oldType, $allowedTypes, true)) {
+    $oldType = 'credit';
+}
+
+$pixTypeLabels = [
+    'email' => 'E-mail',
+    'cpf' => 'CPF',
+    'cnpj' => 'CNPJ',
+    'telefone' => 'Telefone',
+    'aleatoria' => 'Chave aleatória',
+];
+
+$normaliseMeta = function ($meta) {
+    if (is_string($meta)) {
+        $decoded = json_decode($meta, true);
+        $meta = is_array($decoded) ? $decoded : [];
+    }
+
+    if (!is_array($meta)) {
+        return [];
+    }
+
+    $clean = [];
+    foreach ($meta as $k => $v) {
+        if (!is_string($k)) {
+            continue;
+        }
+        $value = trim((string)$v);
+        if ($value === '') {
+            continue;
+        }
+        $clean[$k] = $value;
+    }
+
+    return $clean;
+};
+
+foreach ($methods as &$methodItem) {
+    $methodItem = is_array($methodItem) ? $methodItem : [];
+    $methodItem['meta'] = $normaliseMeta($methodItem['meta'] ?? []);
+    $methodItem['type'] = is_string($methodItem['type'] ?? null) ? $methodItem['type'] : 'others';
+    $methodItem['name'] = (string)($methodItem['name'] ?? '');
+    $methodItem['instructions'] = (string)($methodItem['instructions'] ?? '');
+    $methodItem['sort_order'] = isset($methodItem['sort_order']) ? (int)$methodItem['sort_order'] : 0;
+    $methodItem['active'] = !empty($methodItem['active']) ? 1 : 0;
+}
+unset($methodItem);
+
+$pixMethods = array_filter($methods, fn($m) => ($m['type'] ?? '') === 'pix');
+$otherMethods = array_filter($methods, fn($m) => ($m['type'] ?? '') !== 'pix');
 
 $slug = rawurlencode((string)($company['slug'] ?? ''));
 $title = $title ?? ('Métodos de pagamento - ' . ($company['name'] ?? ''));
@@ -42,19 +145,46 @@ ob_start();
     </a>
   </div>
     <script>
-      (function(){
+      document.addEventListener('DOMContentLoaded', function(){
         const type = document.getElementById('pm-type');
         const pixFields = document.getElementById('pm-pix-fields');
-        function togglePix(){
-          if (!type || !pixFields) return;
-          if (type.value === 'pix') {
-            pixFields.classList.remove('hidden');
-          } else {
-            pixFields.classList.add('hidden');
+        const nameField = document.getElementById('pm-name-field');
+        const nameInput = document.getElementById('pm-name');
+
+        function togglePixFields(){
+          if (!type) return;
+          const isPix = type.value === 'pix';
+          if (pixFields) {
+            pixFields.classList.toggle('hidden', !isPix);
+          }
+          if (nameField) {
+            nameField.classList.toggle('hidden', isPix);
+          }
+          if (nameInput) {
+            if (!nameInput.dataset.originalRequired) {
+              nameInput.dataset.originalRequired = nameInput.hasAttribute('required') ? '1' : '0';
+            }
+            if (isPix) {
+              nameInput.removeAttribute('required');
+              if (!nameInput.value) {
+                nameInput.value = 'Pix';
+              }
+            } else if (nameInput.dataset.originalRequired === '1') {
+              nameInput.setAttribute('required', 'required');
+            }
+          }
+          if (typeof window.pmUpdatePixFeedback === 'function') {
+            window.pmUpdatePixFeedback();
           }
         }
-        if (type){ type.addEventListener('change', togglePix); togglePix(); }
-      })();
+
+        window.pmTogglePixFields = togglePixFields;
+
+        if (type){
+          type.addEventListener('change', togglePixFields);
+          togglePixFields();
+        }
+      });
     </script>
 </header>
 
@@ -84,7 +214,7 @@ ob_start();
         <input type="hidden" name="csrf_token" value="<?= e(csrf_token()) ?>">
       <?php endif; ?>
 
-      <label class="grid gap-1 text-sm">
+      <label id="pm-name-field" class="grid gap-1 text-sm <?= $oldType === 'pix' ? 'hidden' : '' ?>">
         <span class="font-semibold text-slate-700">Nome da bandeira</span>
         <input id="pm-name" type="text" name="name" value="<?= e($old['name'] ?? '') ?>" placeholder="Ex.: Visa, MasterCard, Pix, Dinheiro" class="rounded-xl border border-slate-300 bg-white px-3 py-2 shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" required autofocus aria-describedby="pm-name-help">
         <div id="pm-name-help" class="text-xs text-slate-400">Nome exibido ao cliente no checkout (ex.: Visa, Pix).</div>
@@ -93,11 +223,11 @@ ob_start();
       <label class="grid gap-1 text-sm">
         <span class="font-semibold text-slate-700">Tipo</span>
         <select name="type" id="pm-type" class="rounded-xl border border-slate-300 bg-white px-3 py-2 shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200">
-          <option value="credit">Crédito</option>
-          <option value="debit">Débito</option>
-          <option value="others">Outros</option>
-          <option value="voucher">Vale-refeição</option>
-          <option value="pix">Pix</option>
+          <option value="credit" <?= $oldType === 'credit' ? 'selected' : '' ?>>Crédito</option>
+          <option value="debit" <?= $oldType === 'debit' ? 'selected' : '' ?>>Débito</option>
+          <option value="others" <?= $oldType === 'others' ? 'selected' : '' ?>>Outros</option>
+          <option value="voucher" <?= $oldType === 'voucher' ? 'selected' : '' ?>>Vale-refeição</option>
+          <option value="pix" <?= $oldType === 'pix' ? 'selected' : '' ?>>Pix</option>
         </select>
       </label>
 
@@ -106,15 +236,26 @@ ob_start();
         <textarea name="instructions" rows="3" placeholder="Recados exibidos após a escolha do cliente" class="rounded-xl border border-slate-300 bg-white px-3 py-2 shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200"><?= e($old['instructions'] ?? '') ?></textarea>
       </label>
 
-      <div id="pm-pix-fields" class="hidden grid gap-2">
+      <div id="pm-pix-fields" class="<?= $oldType === 'pix' ? 'grid gap-2' : 'hidden grid gap-2' ?>">
         <h3 class="text-sm font-semibold">Credenciais Pix</h3>
         <label class="grid gap-1 text-sm">
           <span class="font-semibold text-slate-700">Chave Pix</span>
-          <input type="text" name="meta[px_key]" placeholder="Ex.: 11999999999 ou chave aleatória" class="rounded-xl border border-slate-300 bg-white px-3 py-2 shadow-sm">
+          <input id="pm-pix-key" type="text" name="meta[px_key]" value="<?= e($old['meta']['px_key'] ?? '') ?>" placeholder="Ex.: 11999999999 ou chave aleatória" class="rounded-xl border border-slate-300 bg-white px-3 py-2 shadow-sm">
+          <div id="pm-pix-key-feedback" class="text-xs text-slate-400">
+            <?php if (!empty($old['meta']['px_key_type'])): ?>
+              Tipo identificado: <?= e($pixTypeLabels[$old['meta']['px_key_type']] ?? ucfirst($old['meta']['px_key_type'])) ?>
+            <?php else: ?>
+              Informe a chave para identificar automaticamente o tipo.
+            <?php endif; ?>
+          </div>
         </label>
         <label class="grid gap-1 text-sm">
           <span class="font-semibold text-slate-700">Provedor (opcional)</span>
-          <input type="text" name="meta[px_provider]" placeholder="Ex.: Gerencianet, Pagar.me" class="rounded-xl border border-slate-300 bg-white px-3 py-2 shadow-sm">
+          <input type="text" name="meta[px_provider]" value="<?= e($old['meta']['px_provider'] ?? '') ?>" placeholder="Ex.: Gerencianet, Pagar.me" class="rounded-xl border border-slate-300 bg-white px-3 py-2 shadow-sm">
+        </label>
+        <label class="grid gap-1 text-sm">
+          <span class="font-semibold text-slate-700">Nome do titular Pix</span>
+          <input type="text" name="meta[px_holder_name]" value="<?= e($old['meta']['px_holder_name'] ?? '') ?>" placeholder="Ex.: João da Silva" class="rounded-xl border border-slate-300 bg-white px-3 py-2 shadow-sm">
         </label>
       </div>
 
@@ -129,10 +270,12 @@ ob_start();
         </label>
       </div>
 
+      <input type="hidden" name="method_id" id="pm-method-id" value="<?= isset($old['id']) ? (int)$old['id'] : '' ?>">
+
       <div class="flex gap-3">
         <button type="submit" class="inline-flex items-center gap-2 rounded-xl admin-gradient-bg px-4 py-2 text-sm font-medium text-white shadow hover:opacity-95">
           <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none"><path d="M4 12h16M12 4v16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
-          Adicionar método
+          <span id="pm-submit-label">Adicionar método</span>
         </button>
         <a href="<?= e(base_url('admin/' . $slug . '/dashboard')) ?>" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50">Cancelar</a>
       </div>
@@ -141,77 +284,86 @@ ob_start();
 
   <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
     <h2 class="text-lg font-semibold text-slate-800">Métodos cadastrados</h2>
-    <?php if (!$methods): ?>
-      <p class="text-sm text-slate-500">Ainda não há métodos cadastrados. Utilize o formulário ao lado para iniciar.</p>
-    <?php endif; ?>
-
-    <!-- Tabs (exemplo visual) -->
     <div class="mt-3 flex items-center justify-between">
-      <div class="flex gap-4 border-b">
-        <button class="pb-2 text-sm font-medium border-b-2 border-rose-600 text-rose-600">Crédito</button>
-        <button class="pb-2 text-sm text-slate-500">Débito</button>
-        <button class="pb-2 text-sm text-slate-500">Outros</button>
-        <button class="pb-2 text-sm text-slate-500">Vale-refeição</button>
-      </div>
+      <div class="text-sm font-medium text-slate-600">Gerencie os métodos cadastrados abaixo.</div>
       <div class="flex items-center gap-3 text-sm text-slate-600">
         <span>Ativar todas</span>
         <label class="inline-flex items-center cursor-pointer">
           <input id="pm-toggle-all" type="checkbox" class="sr-only">
-          <span class="w-10 h-6 bg-slate-200 rounded-full relative transition-colors">
-            <span class="absolute left-0.5 top-0.5 w-5 h-5 bg-white rounded-full shadow transform transition-transform" style="transform: translateX(0)"></span>
+          <span class="pm-toggle-all-track w-10 h-6 bg-slate-200 rounded-full relative transition-colors">
+            <span class="pm-toggle-all-thumb absolute left-0.5 top-0.5 w-5 h-5 bg-white rounded-full shadow transform transition-transform" style="transform: translateX(0)"></span>
           </span>
         </label>
       </div>
     </div>
 
-    <div class="mt-4">
-      <div class="space-y-2" id="pm-list">
-      <?php foreach ($methods as $method):
-          $methodId = (int)($method['id'] ?? 0);
-          $methodSlug = $base . '/' . $methodId;
-          $isActive = !empty($method['active']);
-          ?>
-        <div class="flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50 px-4 py-3">
-          <div class="flex items-center gap-3">
-            <div class="w-8 h-8 rounded-md bg-white flex items-center justify-center border border-slate-200">
-              <svg class="h-4 w-4 text-slate-500" viewBox="0 0 24 24" fill="none"><path d="M3 7h18M7 11h10M5 15h14" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            </div>
-            <div>
-              <div class="flex items-center gap-2">
-                <div class="font-semibold text-slate-800"><?= e($method['name'] ?? '') ?></div>
-                <?php $type = $method['type'] ?? 'others'; ?>
-                <div class="text-xs rounded-full px-2 py-1 <?= $type === 'pix' ? 'bg-emerald-100 text-emerald-700' : ($type === 'credit' ? 'bg-rose-100 text-rose-700' : 'bg-slate-100 text-slate-700') ?>"><?= e(ucfirst($type)) ?></div>
-              </div>
-              <?php if (!empty($method['type']) && $method['type'] === 'pix' && !empty($method['meta'])):
-                  $m = is_string($method['meta']) ? json_decode($method['meta'], true) : (is_array($method['meta']) ? $method['meta'] : []);
-                  $px = $m['px_key'] ?? null;
-              ?>
-                <?php if ($px): ?><div class="text-xs text-slate-500">Chave Pix: <?= e($px) ?></div><?php endif; ?>
-              <?php endif; ?>
-              <div class="text-xs text-slate-500">ID #<?= $methodId ?></div>
-            </div>
-          </div>
-          <div class="flex items-center gap-3">
-            <label class="inline-flex items-center cursor-pointer">
-              <input data-id="<?= $methodId ?>" type="checkbox" class="pm-toggle sr-only" <?= $isActive ? 'checked' : '' ?> />
-              <span class="w-10 h-6 <?= $isActive ? 'bg-rose-500' : 'bg-slate-200' ?> rounded-full relative transition-colors">
-                <span class="absolute left-0.5 top-0.5 w-5 h-5 bg-white rounded-full shadow transform transition-transform" style="transform: translateX(<?= $isActive ? '20px' : '0' ?>)"></span>
-              </span>
-            </label>
-            <a href="#" class="text-sm text-slate-500">Editar</a>
-          </div>
+    <div class="mt-4 space-y-4">
+      <div id="pm-pix-block" class="<?= $pixMethods ? '' : 'hidden' ?>">
+        <h3 class="mb-2 text-sm font-semibold text-slate-700">Pix</h3>
+        <div class="space-y-2" id="pm-pix-list">
+          <?php foreach ($pixMethods as $method): ?>
+            <?= render_payment_method_row($method, $pixTypeLabels, $base) ?>
+          <?php endforeach; ?>
         </div>
-      <?php endforeach; ?>
+      </div>
+
+      <div class="space-y-2" id="pm-list">
+        <?php foreach ($otherMethods as $method): ?>
+          <?= render_payment_method_row($method, $pixTypeLabels, $base) ?>
+        <?php endforeach; ?>
+      </div>
+
+      <div id="pm-empty" class="<?= $methods ? 'hidden' : 'text-sm text-slate-500' ?>">
+        Ainda não há métodos cadastrados. Utilize o formulário ao lado para iniciar.
       </div>
     </div>
 
-    <script>
+        <script>
       (function(){
         const base = '<?= $base ?>';
         const csrftoken = <?= function_exists('csrf_token') ? ('"' . addslashes(csrf_token()) . '"') : 'null' ?>;
+        const list = document.getElementById('pm-list');
+        const pixList = document.getElementById('pm-pix-list');
+        const pixBlock = document.getElementById('pm-pix-block');
+        const emptyMessage = document.getElementById('pm-empty');
+        const toggleAll = document.getElementById('pm-toggle-all');
+        const toggleAllTrack = document.querySelector('.pm-toggle-all-track');
+        const toggleAllThumb = document.querySelector('.pm-toggle-all-thumb');
+        const form = document.getElementById('pm-create-form');
+        const typeSelect = document.getElementById('pm-type');
+        const nameInput = document.getElementById('pm-name');
+        const pixKeyInput = document.getElementById('pm-pix-key');
+        const pixKeyFeedback = document.getElementById('pm-pix-key-feedback');
+        const pixProviderInput = document.querySelector('input[name="meta[px_provider]"]');
+        const pixHolderInput = document.querySelector('input[name="meta[px_holder_name]"]');
+        const methodIdInput = document.getElementById('pm-method-id');
+        const submitLabel = document.getElementById('pm-submit-label');
+        const instructionsInput = document.querySelector('textarea[name="instructions"]');
+        const sortOrderInput = document.querySelector('input[name="sort_order"]');
+        const activeInput = document.querySelector('input[name="active"]');
+        let editingId = null;
+        let defaultSortOrder = sortOrderInput ? sortOrderInput.value : '';
 
-        function escapeHtml(s){
-          return (s + '')
+        const pixTypeLabels = <?= json_encode($pixTypeLabels, JSON_UNESCAPED_UNICODE) ?>;
+
+        function detectPixKeyType(key) {
+          key = (key || '').trim();
+          if (!key) return '';
+          if (/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(key)) return 'email';
+          const digits = key.replace(/\D+/g, '');
+          if (digits.length === 11) return 'cpf';
+          if (digits.length === 14) return 'cnpj';
+          if (digits.length >= 10 && digits.length <= 13) return 'telefone';
+          return 'aleatoria';
+        }
+
+        function formatPixKeyType(type) {
+          if (!type) return '';
+          return pixTypeLabels[type] || (type.charAt(0).toUpperCase() + type.slice(1));
+        }
+
+        function escapeHtml(value) {
+          return (value == null ? '' : String(value))
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
@@ -219,12 +371,132 @@ ob_start();
             .replace(/'/g, '&#039;');
         }
 
-        // render a method row element
-        function renderMethodRow(method){
+        function updatePixKeyFeedback() {
+          if (!pixKeyFeedback) return;
+          const key = pixKeyInput ? pixKeyInput.value : '';
+          if (!key) {
+            pixKeyFeedback.textContent = 'Informe a chave para identificar automaticamente o tipo.';
+            return;
+          }
+          const detected = detectPixKeyType(key);
+          pixKeyFeedback.textContent = 'Tipo identificado: ' + formatPixKeyType(detected || 'aleatoria');
+        }
+
+        window.pmUpdatePixFeedback = updatePixKeyFeedback;
+
+        if (pixKeyInput) {
+          pixKeyInput.addEventListener('input', updatePixKeyFeedback);
+          updatePixKeyFeedback();
+        }
+
+        function updateEmptyStates() {
+          if (pixBlock && pixList) {
+            pixBlock.classList.toggle('hidden', pixList.children.length === 0);
+          }
+          if (emptyMessage && list) {
+            const total = list.children.length + (pixList ? pixList.children.length : 0);
+            emptyMessage.classList.toggle('hidden', total > 0);
+          }
+        }
+
+        function setToggleVisual(track, on) {
+          if (!track) return;
+          track.classList.toggle('bg-rose-500', !!on);
+          track.classList.toggle('bg-slate-200', !on);
+          const thumb = track.querySelector('.pm-toggle-thumb');
+          if (thumb) {
+            thumb.style.transform = on ? 'translateX(20px)' : 'translateX(0)';
+          }
+        }
+
+        function setToggleAllVisual(on) {
+          if (!toggleAllTrack || !toggleAllThumb) return;
+          toggleAllTrack.classList.toggle('bg-rose-500', !!on);
+          toggleAllTrack.classList.toggle('bg-slate-200', !on);
+          toggleAllThumb.style.transform = on ? 'translateX(20px)' : 'translateX(0)';
+        }
+
+        function refreshToggleAllState() {
+          if (!toggleAll) return;
+          const toggles = document.querySelectorAll('.pm-row .pm-toggle');
+          if (!toggles.length) {
+            toggleAll.checked = false;
+            setToggleAllVisual(false);
+            return;
+          }
+          const allChecked = Array.from(toggles).every(chk => chk.checked);
+          toggleAll.checked = allChecked;
+          setToggleAllVisual(allChecked);
+        }
+
+        function parseMethodData(node) {
+          if (!node) return null;
+          try {
+            return JSON.parse(node.dataset.method || '{}');
+          } catch (err) {
+            return null;
+          }
+        }
+
+        function wireRowInteractions(row) {
+          if (!row) return;
+          const checkbox = row.querySelector('.pm-toggle');
+          if (checkbox && !checkbox.dataset.wired) {
+            checkbox.dataset.wired = '1';
+            checkbox.addEventListener('change', function(){
+              const id = this.dataset.id;
+              const on = this.checked;
+              const track = row.querySelector('.pm-toggle-track');
+              setToggleVisual(track, on);
+              toggleMethod(id, on, row, function(success){
+                if (!success) {
+                  checkbox.checked = !on;
+                  setToggleVisual(track, checkbox.checked);
+                }
+              });
+            });
+          }
+
+          const editBtn = row.querySelector('.pm-edit');
+          if (editBtn && !editBtn.dataset.wired) {
+            editBtn.dataset.wired = '1';
+            editBtn.addEventListener('click', function(){
+              const data = parseMethodData(row);
+              if (data) {
+                fillFormWithMethod(data);
+              }
+            });
+          }
+        }
+
+        function createPixInfo(method) {
+          if (method.type !== 'pix' || !method.meta) return '';
+          let html = '';
+          if (method.meta.px_key) {
+            html += `
+                <div class="text-xs text-slate-500">Chave Pix: ${escapeHtml(method.meta.px_key)}</div>`;
+          }
+          if (method.meta.px_key_type) {
+            html += `
+                <div class="text-xs text-slate-500">Tipo da chave: ${escapeHtml(formatPixKeyType(method.meta.px_key_type))}</div>`;
+          }
+          if (method.meta.px_holder_name) {
+            html += `
+                <div class="text-xs text-slate-500">Titular: ${escapeHtml(method.meta.px_holder_name)}</div>`;
+          }
+          return html;
+        }
+
+        function renderMethodRow(method) {
           const id = parseInt(method.id, 10);
+          const type = method.type || 'others';
           const isActive = parseInt(method.active, 10) === 1;
           const div = document.createElement('div');
-          div.className = 'flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50 px-4 py-3';
+          div.className = 'pm-row flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50 px-4 py-3';
+          div.dataset.id = String(id);
+          div.dataset.type = type;
+          div.dataset.method = JSON.stringify(method);
+          const typeBadge = type === 'pix' ? 'bg-emerald-100 text-emerald-700' : (type === 'credit' ? 'bg-rose-100 text-rose-700' : 'bg-slate-100 text-slate-700');
           div.innerHTML = `
             <div class="flex items-center gap-3">
               <div class="w-8 h-8 rounded-md bg-white flex items-center justify-center border border-slate-200">
@@ -233,135 +505,224 @@ ob_start();
               <div>
                 <div class="flex items-center gap-2">
                   <div class="font-semibold text-slate-800">${escapeHtml(method.name || '')}</div>
-                  <div class="text-xs rounded-full px-2 py-1 ${method.type === 'pix' ? 'bg-emerald-100 text-emerald-700' : (method.type === 'credit' ? 'bg-rose-100 text-rose-700' : 'bg-slate-100 text-slate-700')}">${escapeHtml((method.type || 'others').charAt(0).toUpperCase() + (method.type || 'others').slice(1))}</div>
-                </div>
-                ${method.type === 'pix' && method.meta && method.meta.px_key ? `<div class="text-xs text-slate-500">Chave Pix: ${escapeHtml(method.meta.px_key)}</div>` : ''}
+                  <div class="text-xs rounded-full px-2 py-1 ${typeBadge}">${escapeHtml(type.charAt(0).toUpperCase() + type.slice(1))}</div>
+                </div>${createPixInfo(method)}
                 <div class="text-xs text-slate-500">ID #${id}</div>
               </div>
             </div>
             <div class="flex items-center gap-3">
               <label class="inline-flex items-center cursor-pointer">
                 <input data-id="${id}" type="checkbox" class="pm-toggle sr-only" ${isActive ? 'checked' : ''} />
-                <span class="w-10 h-6 ${isActive ? 'bg-rose-500' : 'bg-slate-200'} rounded-full relative transition-colors">
-                  <span class="absolute left-0.5 top-0.5 w-5 h-5 bg-white rounded-full shadow transform transition-transform" style="transform: translateX(${isActive ? '20px' : '0'})"></span>
+                <span class="pm-toggle-track w-10 h-6 ${isActive ? 'bg-rose-500' : 'bg-slate-200'} rounded-full relative transition-colors">
+                  <span class="pm-toggle-thumb absolute left-0.5 top-0.5 w-5 h-5 bg-white rounded-full shadow transform transition-transform" style="transform: ${isActive ? 'translateX(20px)' : 'translateX(0)'}"></span>
                 </span>
               </label>
-              <a href="#" class="text-sm text-slate-500">Editar</a>
+              <button type="button" class="pm-edit text-sm text-slate-500" data-id="${id}">Editar</button>
             </div>
           `;
-
-          const chk = div.querySelector('.pm-toggle');
-          if (chk){
-            chk.addEventListener('change', function(){
-              const on = this.checked;
-              toggleMethod(id, on, function(success){ if (!success) chk.checked = !on; });
-            });
-          }
-
+          wireRowInteractions(div);
           return div;
         }
 
-        async function toggleMethod(id, on, cb){
-          try{
+        function replaceMethodRow(method) {
+          const id = String(method.id);
+          const newRow = renderMethodRow(method);
+          const existing = document.querySelector('.pm-row[data-id="' + id + '"]');
+          const target = method.type === 'pix' ? pixList : list;
+          if (existing && existing.parentNode) {
+            const parent = existing.parentNode;
+            const nextSibling = existing.nextSibling;
+            existing.parentNode.removeChild(existing);
+            if (target && parent === target && nextSibling) {
+              target.insertBefore(newRow, nextSibling);
+            } else if (target && parent === target) {
+              target.appendChild(newRow);
+            } else if (target) {
+              target.insertBefore(newRow, target.firstChild);
+            }
+          } else if (target) {
+            target.insertBefore(newRow, target.firstChild);
+          }
+          updateEmptyStates();
+          refreshToggleAllState();
+        }
+
+        function fillFormWithMethod(method) {
+          if (!form) return;
+          editingId = parseInt(method.id, 10) || null;
+          form.action = editingId ? (base + '/' + editingId) : base;
+          if (methodIdInput) {
+            methodIdInput.value = editingId ? editingId : '';
+          }
+          if (nameInput) {
+            nameInput.value = method.type === 'pix' ? 'Pix' : (method.name || '');
+          }
+          if (instructionsInput) {
+            instructionsInput.value = method.instructions || '';
+          }
+          if (sortOrderInput) {
+            sortOrderInput.value = method.sort_order != null ? method.sort_order : '';
+          }
+          if (activeInput) {
+            activeInput.checked = parseInt(method.active, 10) === 1;
+          }
+          if (typeSelect) {
+            typeSelect.value = method.type || 'others';
+          }
+          if (pixKeyInput) {
+            pixKeyInput.value = method.meta && method.meta.px_key ? method.meta.px_key : '';
+          }
+          if (pixProviderInput) {
+            pixProviderInput.value = method.meta && method.meta.px_provider ? method.meta.px_provider : '';
+          }
+          if (pixHolderInput) {
+            pixHolderInput.value = method.meta && method.meta.px_holder_name ? method.meta.px_holder_name : '';
+          }
+          if (submitLabel) {
+            submitLabel.textContent = 'Atualizar método';
+          }
+          if (typeof window.pmTogglePixFields === 'function') {
+            window.pmTogglePixFields();
+          }
+          updatePixKeyFeedback();
+          if (form.scrollIntoView) {
+            form.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }
+        }
+
+        function resetForm(nextSortOrder) {
+          if (!form) return;
+          editingId = null;
+          form.action = base;
+          if (submitLabel) {
+            submitLabel.textContent = 'Adicionar método';
+          }
+          if (methodIdInput) {
+            methodIdInput.value = '';
+          }
+          if (nameInput) {
+            nameInput.value = '';
+          }
+          if (instructionsInput) {
+            instructionsInput.value = '';
+          }
+          if (sortOrderInput) {
+            sortOrderInput.value = nextSortOrder !== undefined ? nextSortOrder : defaultSortOrder;
+          }
+          if (activeInput) {
+            activeInput.checked = true;
+          }
+          if (typeSelect) {
+            typeSelect.value = 'credit';
+          }
+          if (pixKeyInput) {
+            pixKeyInput.value = '';
+          }
+          if (pixProviderInput) {
+            pixProviderInput.value = '';
+          }
+          if (pixHolderInput) {
+            pixHolderInput.value = '';
+          }
+          if (typeof window.pmTogglePixFields === 'function') {
+            window.pmTogglePixFields();
+          }
+          updatePixKeyFeedback();
+        }
+
+        function applyToggleStateToRow(row, on) {
+          if (!row) return;
+          const checkbox = row.querySelector('.pm-toggle');
+          if (checkbox) {
+            checkbox.checked = !!on;
+          }
+          const track = row.querySelector('.pm-toggle-track');
+          setToggleVisual(track, on);
+        }
+
+        async function toggleMethod(id, on, row, cb) {
+          try {
             const url = base + '/' + id;
             const body = new URLSearchParams();
             body.append('active', on ? '1' : '0');
             if (csrftoken) body.append('csrf_token', csrftoken);
-            const res = await fetch(url, { method: 'POST', body: body, credentials: 'same-origin' });
+            const res = await fetch(url, { method: 'POST', body, credentials: 'same-origin' });
             if (!res.ok) throw new Error('Network');
-            const json = await res.json().catch(()=>null);
-            if (cb) cb(!!json && json.success);
-            return !!json && json.success;
-          } catch(e){
-            console.error(e);
+            const json = await res.json().catch(() => null);
+            if (!json || !json.success) throw new Error('Invalid response');
+            if (json.method) {
+              replaceMethodRow(json.method);
+            } else if (row) {
+              applyToggleStateToRow(row, on);
+            }
+            if (cb) cb(true);
+            return true;
+          } catch (err) {
+            console.error(err);
             alert('Erro ao atualizar o método. Atualize a página e tente novamente.');
             if (cb) cb(false);
             return false;
+          } finally {
+            refreshToggleAllState();
           }
         }
 
-        // wire existing toggles
-        function wireExistingToggles(){
-          document.querySelectorAll('.pm-toggle').forEach(function(chk){
-            if (chk.dataset.wired) return;
-            chk.dataset.wired = '1';
-            chk.addEventListener('change', function(){
-              const id = this.dataset.id;
-              const on = this.checked;
-              toggleMethod(id, on, function(success){ if (!success) chk.checked = !on; });
-            });
-          });
-        }
-
-        wireExistingToggles();
-
-        const toggleAll = document.getElementById('pm-toggle-all');
-        if (toggleAll){
+        if (toggleAll) {
           toggleAll.addEventListener('change', async function(){
-            const on = this.checked ? '1' : '0';
-            try{
+            const on = this.checked;
+            setToggleAllVisual(on);
+            try {
               const url = base + '/batch';
               const body = new URLSearchParams();
-              body.append('active', on);
+              body.append('active', on ? '1' : '0');
               if (csrftoken) body.append('csrf_token', csrftoken);
-              const res = await fetch(url, { method: 'POST', body: body, credentials: 'same-origin' });
+              const res = await fetch(url, { method: 'POST', body, credentials: 'same-origin' });
               if (!res.ok) throw new Error('Network');
-              const json = await res.json().catch(()=>null);
+              const json = await res.json().catch(() => null);
               if (!json || !json.success) throw new Error('Batch failed');
-
-              // update UI without firing individual toggles
-              document.querySelectorAll('.pm-toggle').forEach(function(chk){
-                chk.checked = toggleAll.checked;
-                const span = chk.parentElement.querySelector('span.w-10');
-                if (span){
-                  if (chk.checked) span.classList.remove('bg-slate-200'), span.classList.add('bg-rose-500');
-                  else span.classList.remove('bg-rose-500'), span.classList.add('bg-slate-200');
-                  const ball = span.querySelector('span.absolute');
-                  if (ball) ball.style.transform = 'translateX(' + (chk.checked ? '20px' : '0') + ')';
-                }
+              document.querySelectorAll('.pm-row').forEach(function(row){
+                applyToggleStateToRow(row, on);
               });
-            }catch(e){
-              console.error(e);
+            } catch (err) {
+              console.error(err);
               alert('Erro ao atualizar todos os métodos. Atualize a página e tente novamente.');
-              // revert toggleAll
-              toggleAll.checked = !toggleAll.checked;
+              this.checked = !on;
+              setToggleAllVisual(this.checked);
             }
           });
         }
 
-        // Submit create form via AJAX and insert new method
-        (function(){
-          const form = document.getElementById('pm-create-form');
-          const list = document.getElementById('pm-list');
-          if (!form || !list || !window.fetch) return;
-
+        if (form) {
           form.addEventListener('submit', async function(e){
-            // if user disabled JS or AJAX not supported, fall back to normal submit
             e.preventDefault();
-
             const data = new FormData(form);
-            if (!data.has('active')) data.set('active', '0');
-            try{
+            if (!data.has('active')) {
+              data.set('active', '0');
+            }
+            const editing = methodIdInput ? methodIdInput.value : '';
+            try {
               const res = await fetch(form.action, { method: form.method || 'POST', body: data, credentials: 'same-origin' });
               if (!res.ok) throw new Error('Network');
-              const json = await res.json().catch(()=>null);
+              const json = await res.json().catch(() => null);
               if (!json || !json.success || !json.method) throw new Error('Invalid response');
-
-              // insert new node at top
-              const node = renderMethodRow(json.method);
-              list.insertBefore(node, list.firstChild);
-              // reset form and UI
-              form.reset();
-              const type = document.getElementById('pm-type');
-              const pixFields = document.getElementById('pm-pix-fields');
-              if (type && pixFields) pixFields.classList.add('hidden');
-            }catch(err){
+              replaceMethodRow(json.method);
+              if (!editing && json.method && json.method.sort_order !== undefined) {
+                const nextSort = (parseInt(json.method.sort_order, 10) || 0) + 1;
+                defaultSortOrder = String(nextSort);
+                resetForm(defaultSortOrder);
+              } else {
+                resetForm();
+              }
+            } catch (err) {
               console.error(err);
-              // fallback: submit normally so server can render errors
               form.submit();
             }
           });
-        })();
+        }
+
+        document.querySelectorAll('.pm-row').forEach(wireRowInteractions);
+        updateEmptyStates();
+        refreshToggleAllState();
       })();
     </script>
   </section>


### PR DESCRIPTION
## Summary
- classify Pix keys server-side, persist Pix holder metadata, and handle toggle-only updates without breaking validation
- hide the brand name field for Pix entries, add holder/key type feedback fields, and surface saved Pix methods in a dedicated block
- enhance the admin list with working toggles, inline editing that reuses the form, and client-side Pix key type detection

## Testing
- php -l app/controllers/AdminPaymentMethodController.php
- php -l app/views/admin/payments/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e2f196b684832eb7b3fde831042fe3